### PR TITLE
[fr-fr] Fix the issues

### DIFF
--- a/assets/texts/fr/Changelog/0.1.html
+++ b/assets/texts/fr/Changelog/0.1.html
@@ -1,8 +1,0 @@
-<ul>
-	<li><strong>Mis en avant :</strong></li>
-	<li><strong>Nouveauté :</strong></li>
-	<li><strong>Corrigé :</strong></li>
-	<li><strong>Interne :</strong></li>
-</ul>
-
-More information <a href="https://github.com/rugk/awesome-emoji-picker/releases/tag/v0.1">on GitHub</a>.

--- a/assets/texts/fr/Changelog/0.1.md
+++ b/assets/texts/fr/Changelog/0.1.md
@@ -1,4 +1,0 @@
-* **Mis en avant :** 
-* **Nouveauté :** 
-* **Corrigé :** 
-* **Interne :** 

--- a/assets/texts/fr/Changelog/1.0.html
+++ b/assets/texts/fr/Changelog/1.0.html
@@ -1,0 +1,11 @@
+<ul>
+	<li><strong>Nouveau :</strong> Toutes les fonctionalités pour la v1.0 ont été implémentées.</li>
+	<li><strong>Nouveau :</strong> Sélectionnez n'importe quel émoji et copiez-le.</li>
+	<li><strong>Nouveau :</strong> L'insère directement dans la page courante, si désiré.</li>
+	<li><strong>Nouveau :</strong> Options ajustables pour la taille des émojis, du sélecteur, des styles d'émojis, etc.
+	</li>
+	<li><strong>Nouveau :</strong> Affiche un message de confirmation, si l'action a été réalisée.</li>
+	<li>Et bien plus !</li>
+</ul>
+
+Plus d'informations <a href="https://github.com/rugk/awesome-emoji-picker/releases/tag/v1.0">sur GitHub</a>.

--- a/assets/texts/fr/Changelog/1.0.md
+++ b/assets/texts/fr/Changelog/1.0.md
@@ -1,0 +1,6 @@
+* **Nouveau :** Toutes les fonctionalités pour la v1.0 ont été implémentées.
+* **Nouveau :** Sélectionnez n'importe quel émoji et copiez-le.
+* **Nouveau :** L'insère directement dans la page courante, si désiré.
+* **Nouveau :** Options ajustables pour la taille des émojis, du sélecteur, des styles d'émojis, etc.
+* **Nouveau :** Affiche un message de confirmation, si l'action a été réalisée.
+* Et bien plus !

--- a/assets/texts/fr/amoSummary.txt
+++ b/assets/texts/fr/amoSummary.txt
@@ -1,4 +1,3 @@
-Ce module complémentaire vous donne un bon petit sélecteur d'émoticônes que vous pouvez pour en trouver 🔎 et en sélectionner. 😀
-Il sera ajouté à votre presse-papier 📋 (de façon similaire à un "copier-coller") quand vous cliquez 🖱️ dessus.
+Ce module complémentaire vous donne un sélecteur d'émoji moderne pour en trouver 🔎 et les utiliser. 😀 Il sera ajouté à votre presse-papier 📋 (copie du "copier-coller"), ou inséré directement, quand vous cliquez 🖱️ dessus.
 
 Vous allez l'adorer. 😎

--- a/assets/texts/fr/amoSummary.txt
+++ b/assets/texts/fr/amoSummary.txt
@@ -1,2 +1,4 @@
 Ce module complémentaire vous donne un bon petit sélecteur d'émoticônes que vous pouvez pour en trouver 🔎 et en sélectionner. 😀
 Il sera ajouté à votre presse-papier 📋 (de façon similaire à un "copier-coller") quand vous cliquez 🖱️ dessus.
+
+Vous allez l'adorer. 😎

--- a/assets/texts/fr/amoSummary.txt
+++ b/assets/texts/fr/amoSummary.txt
@@ -1,3 +1,3 @@
-Ce module complémentaire vous donne un sélecteur d'émoji moderne pour en trouver 🔎 et les utiliser. 😀 Il sera ajouté à votre presse-papier 📋 (copie du "copier-coller"), ou inséré directement, quand vous cliquez 🖱️ dessus.
+Ce module complémentaire vous donne un sélecteur d'émoji moderne pour en trouver 🔎 et les utiliser. 😀 Il sera ajouté à votre presse-papier 📋 ("Copier-coller"), ou inséré directement, quand vous cliquez 🖱️ dessus.
 
 Vous allez l'adorer. 😎

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -71,15 +71,15 @@
   },
   // confirmation hints
   "confirmationHintEmojiCopied": {
-    "message": "Emoji copied",
+    "message": "Emoji copié",
     "description": "The confirmation shown, if an emoji has been copied to clipboard. Try to keep it short, as it is a big message."
   },
   "confirmationHintEmojiInserted": {
-    "message": "Emoji inserted",
+    "message": "Emoji inséré",
     "description": "The confirmation shown, if an emoji has been inserted into the active web page. Try to keep it short, as it is a big message."
   },
   "confirmationHintEmojiCopiedAndInserted": {
-    "message": "Emoji copied & inserted",
+    "message": "Emoji copié & inséré",
     "description": "The confirmation shown, if an emoji has been copied to the clipboard *and* has been inserted into the active web page. Try to keep it short, as it is a big message."
   },
   // tips


### PR DESCRIPTION
Fix the issues mentioned in #26 by @rugk: 

> * the short add-on description for AMO _must only_ be 250 characters long. You have 20 too much:
> ![image](https://user-images.githubusercontent.com/11966684/57956158-5bdddd00-78f8-11e9-8c6a-066358cc0b8d.png)
> (I've now just cut the last part in [1a8a2e9](https://github.com/rugk/awesome-emoji-picker/commit/1a8a2e9d81f2fee97d1b4d8c52274a1bdda58ad5), but it would obviously be good to find a better solution, if possible that includes all the text.)

>  * you missed the changelog. The v0.1 is not needed anymore. If you want to translate it, please translate the v1.0.

[Link](https://github.com/rugk/awesome-emoji-picker/pull/26#issuecomment-493601334)
