### PR TITLE
Add dark mode for popup

### DIFF
--- a/src/common/variables.css
+++ b/src/common/variables.css
@@ -34,6 +34,7 @@
 
   --red-60: #d70022;
 
+  --grey-10: #f9f9fa;
   --grey-20: #ededf0;
   --grey-30: #d7d7db;
   --grey-40: #b1b1b3;

--- a/src/popup/index.css
+++ b/src/popup/index.css
@@ -1,5 +1,27 @@
 @import "confirmationHint.css";
 
+/* dark mode */
+@media (prefers-color-scheme: dark) {
+  /* sourrounding parts */
+  body {
+    background-color: var(--grey-60);
+  }
+
+  /* overwrite emoji-marts style to use colors more similar to Firefox Photons */
+  .emoji-mart-dark,
+  .emoji-mart-dark .emoji-mart-category-label span {
+    background-color: var(--grey-60) !important;
+  }
+
+  /* increase contrast for text */
+  .emoji-mart-anchor {
+    color: var(--grey-20) !important;
+  }
+  .emoji-mart-preview-shortname {
+    color: var(--grey-10) !important;
+  }
+}
+
 body * {
   /* unset text-align style set by browserStyle from Firefox that causes an issue, see https://github.com/missive/emoji-mart/issues/318 */
   text-align: unset;


### PR DESCRIPTION
With v2.11.2 of emoji-mart introduced (already in master)
This only adjusts some minor design things.
Fixes https://github.com/rugk/awesome-emoji-picker/issues/47

The dark mode now follows the Firefox Photon design in a better way:

![colorAdjust](https://user-images.githubusercontent.com/11966684/71375669-5d266500-25bf-11ea-85e4-b35d8230b81a.png)
