### PR TITLE
Added context menu item

### DIFF
--- a/assets/texts/en/permissions.md
+++ b/assets/texts/en/permissions.md
@@ -1,10 +1,14 @@
 # Requested permissions
 
-For a general explanation of add-on permission see [this support article](https://support.mozilla.org/kb/permission-request-messages-firefox-extensions).
+For a general explanation of add-on permission see [this support article for Firefiox](https://support.mozilla.org/kb/permission-request-messages-firefox-extensions) and [this for Thunderbird](https://support.mozilla.org/kb/permission-request-messages-thunderbird-extensions).
 
 ## Installation permissions
 
-Currently, no permissions are requested at the installation or when updating.
+The following permissions are requested at the installation or when updating:
+
+| Internal Id      | Permission                   | Explanation                                                        |
+|:-----------------|:-----------------------------|:-------------------------------------------------------------------|
+| `[context]menus` | Modify browser context menus | Needed for adding the a context menu item to open the emoji picker |
 
 ## Feature-specific (optional) permissions
 

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -54,7 +54,9 @@
 
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "tabs",
+    "contextMenus"
   ],
 
   "optional_permissions": [

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -53,7 +53,8 @@
 
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "contextMenus"
   ],
 
   "optional_permissions": [

--- a/src/background/background.js
+++ b/src/background/background.js
@@ -1,6 +1,8 @@
 import * as IconHandler from "/common/modules/IconHandler.js";
+import * as ContextMenu from "./modules/ContextMenu.js";
 import * as OmniboxSearch from "./modules/OmniboxSearch.js";
 
 // init modules
 IconHandler.init();
+ContextMenu.init();
 OmniboxSearch.init();

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -1,0 +1,94 @@
+import * as AddonSettings from "/common/modules/AddonSettings/AddonSettings.js";
+import * as BrowserCommunication from "/common/modules/BrowserCommunication/BrowserCommunication.js";
+import { isMobile } from "/common/modules/MobileHelper.js";
+
+import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunicationTypes.js";
+
+// Thunderbird
+const IS_THUNDERBIRD = typeof messenger !== "undefined";
+
+// Chrome
+const IS_CHROME = Object.getPrototypeOf(browser) !== Object.prototype;
+
+const EMOJI = "emoji";
+const menus = browser.menus || browser.contextMenus; // fallback for Thunderbird
+
+/**
+ * Handle context menu click.
+ *
+ * @param {Object} info
+ * @param {Object} tab
+ * @returns {void}
+ */
+function handle(info, tab) {
+    if (info.menuItemId === EMOJI) {
+        // Thunderbird
+        // Not yet enabled by Chrome: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup#browser_compatibility
+        (IS_THUNDERBIRD ? browser.composeAction : browser.browserAction).openPopup();
+    }
+}
+
+/**
+ * Apply new context menu settings.
+ *
+ * @param {Object} contextMenu
+ * @returns {Promise<void>}
+ */
+async function applySettings(contextMenu) {
+    menus.removeAll();
+
+    if (contextMenu.insertEmoji) {
+        // find command
+        const allCommands = await browser.commands.getAll();
+        const commandToFind = IS_THUNDERBIRD ? "_execute_compose_action" : "_execute_browser_action";
+        const popupOpenCommand = allCommands.find((command) => command.name === commandToFind);
+
+        const menuText = `${popupOpenCommand.description || "Insert Emoji"} (${popupOpenCommand.shortcut})`;
+
+        if (IS_CHROME) {
+            menus.create({
+                id: EMOJI,
+                title: menuText,
+                contexts: ["editable"]
+            });
+        } else {
+            menus.create({
+                id: EMOJI,
+                title: menuText,
+                command: commandToFind,
+                // Remove IS_THUNDERBIRD once https://bugzilla.mozilla.org/show_bug.cgi?id=1716976 is fixed
+                contexts: IS_THUNDERBIRD ? ["editable", "selection", "page"] : ["editable"]
+            });
+        }
+    }
+}
+
+/**
+ * Init context menu module.
+ *
+ * @public
+ * @returns {Promise<void>}
+ */
+export async function init() {
+    // Remove once https://bugzilla.mozilla.org/show_bug.cgi?id=1595822 is fixed
+    if (await isMobile()) {
+        return;
+    }
+
+    const contextMenu = await AddonSettings.get("contextMenu");
+
+    applySettings(contextMenu);
+
+    // IS_THUNDERBIRD should not have been needed after https://bugzilla.mozilla.org/show_bug.cgi?id=1681153
+    // Fixed in Thunderbird 99 by https://bugzilla.mozilla.org/show_bug.cgi?id=1751895
+    if (IS_THUNDERBIRD || IS_CHROME) {
+        menus.onClicked.addListener(handle);
+    }
+}
+
+BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.CONTEXT_MENU, (request) => {
+    // clear cache by reloading all options
+    // await AddonSettings.loadOptions();
+
+    return applySettings(request.optionValue);
+});

--- a/src/common/modules/data/BrowserCommunicationTypes.js
+++ b/src/common/modules/data/BrowserCommunicationTypes.js
@@ -13,5 +13,6 @@
  * @type {Object.<string, string>}
  */
 export const COMMUNICATION_MESSAGE_TYPE = Object.freeze({
-    OMNIBAR_TOGGLE: "omnibarToggle"
+    OMNIBAR_TOGGLE: "omnibarToggle",
+    CONTEXT_MENU: "contextMenu"
 });

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -30,6 +30,9 @@ const defaultSettings = {
         resultType: "native",
         showConfirmationMessage: true,
         closePopup: true,
+    contextMenu: {
+        insertEmoji: true
+    },
     },
     emojiSearch: {
         enabled: false,

--- a/src/common/modules/data/DefaultSettings.js
+++ b/src/common/modules/data/DefaultSettings.js
@@ -29,10 +29,10 @@ const defaultSettings = {
         emojiCopyOnlyFallback: false,
         resultType: "native",
         showConfirmationMessage: true,
-        closePopup: true,
+        closePopup: true
+    },
     contextMenu: {
         insertEmoji: true
-    },
     },
     emojiSearch: {
         enabled: false,

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -54,7 +54,8 @@
 
   "permissions": [
     "storage",
-    "activeTab"
+    "activeTab",
+    "contextMenus"
   ],
 
   "optional_permissions": [

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -75,6 +75,23 @@ function applyPickerResultPermissions(optionValue) {
 }
 
 /**
+ * Apply the new context menu settings.
+ *
+ * @private
+ * @param  {Object} optionValue
+ * @param  {string} [option]
+ * @param  {Object} [event]
+ * @returns {void}
+ */
+function applyContextMenuSettings(optionValue, option, event) {
+    // trigger update for current session
+    browser.runtime.sendMessage({
+        type: COMMUNICATION_MESSAGE_TYPE.CONTEXT_MENU,
+        optionValue: optionValue
+    });
+}
+
+/**
  * Adjusts the emoji size setting for saving.
  *
  * @private
@@ -339,6 +356,7 @@ export async function registerTrigger() {
 
     // update slider status
     AutomaticSettings.Trigger.registerSave("pickerResult", applyPickerResultPermissions);
+    AutomaticSettings.Trigger.registerSave("contextMenu", applyContextMenuSettings);
     AutomaticSettings.Trigger.registerSave("popupIconColored", applyPopupIconColor);
     AutomaticSettings.Trigger.registerSave("emojiPicker", updatePerLineStatus);
     AutomaticSettings.Trigger.registerSave("emojiPicker", updateEmojiPerLineMaxViaEmojiSize);

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -19,35 +19,35 @@
 				<a href="#">
 					<button type="button" class="message-action-button micro-button info invisible"></button>
 				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__">
 			</div>
 			<div id="messageInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
 				<span class="message-text">Some settings are managed by your administrator and cannot be changed.</span>
 				<a href="#">
 					<button type="button" class="message-action-button micro-button info invisible"></button>
 				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__">
 			</div>
 			<div id="messageSuccess" aria-label="success message" data-i18n data-i18n-aria-label="__MSG_ariaMessageSuccess__" class="message-box success invisible fade-hide">
 				<span class="message-text">That worked!</span>
 				<a href="#">
 					<button type="button" class="message-action-button micro-button success invisible"></button>
 				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__">
 			</div>
 			<div id="messageError" aria-label="error message" data-i18n data-i18n-aria-label="__MSG_ariaMessageError__" class="message-box error invisible fade-hide">
 				<span class="message-text">An error happened.</span>
 				<a href="#">
 					<button type="button" class="message-action-button micro-button error invisible"></button>
 				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+				<img class="icon-dismiss invisible" src="/common/img/close-white.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__">
 			</div>
 			<div id="messageWarning" aria-label="warning message" data-i18n data-i18n-aria-label="__MSG_ariaMessageWarning__" class="message-box warning invisible fade-hide">
 				<span class="message-text">There were some difficulties.</span>
 				<a href="#">
 					<button type="button" class="message-action-button micro-button warning invisible"></button>
 				</a>
-				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__"></span>
+				<img class="icon-dismiss invisible" src="/common/img/close.svg" width="24" height="24" tabindex="0" data-i18n data-i18n-aria-label="__MSG_dismissIconDescription__">
 			</div>
 		</div>
 		<form>
@@ -115,8 +115,8 @@
 			</section>
 
 			<section>
+				<h1 data-i18n="__MSG_titleBehaviour__">Behavior</h1>
 				<ul>
-					<h1 data-i18n="__MSG_titleBehaviour__">Behaviour</h1>
 					<li>
 						<div class="line">
 							<input class="setting save-on-change" type="checkbox" id="automaticInsert" data-optiongroup="pickerResult" name="automaticInsert">
@@ -158,6 +158,20 @@
 							<input class="setting save-on-change" type="checkbox" id="closePopup" data-optiongroup="pickerResult" name="closePopup">
 							<label data-i18n="__MSG_optionClosePopup__" for="closePopup">Close the popup after an emoji has been selected/inserted.</label>
 						</div>
+					</li>
+				</ul>
+			</section>
+
+			<!-- Remove "mobile-incompatible" once https://bugzilla.mozilla.org/show_bug.cgi?id=1595822 is fixed -->
+			<section class="mobile-incompatible">
+				<h1 data-i18n="">Context menu</h1>
+				<ul>
+					<li>
+						<div class="line">
+							<input class="setting save-on-change" type="checkbox" id="insertEmoji" data-optiongroup="contextMenu" name="insertEmoji">
+							<label data-i18n="" for="insertEmoji">Insert Emoji</label>
+						</div>
+						<span data-i18n="" class="line indent helper-text">Show context menu item to insert emoji.</span>
 					</li>
 				</ul>
 			</section>


### PR DESCRIPTION
* Added context menu item. Fixes #45
![image](https://user-images.githubusercontent.com/15305150/184478495-80532734-ff6b-415a-ada9-ab6ebd8f564e.png)

The item does not need to be localized, as it uses the existing open popup command description from the Manifest file that is already localized.

This is part 2 of the changes needed for Thunderbird support.