### PR TITLE
Removed use of `tabs.executeScript()` and updated manifest files

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,7 +1,7 @@
 {
     "root": true,
     "parserOptions": {
-        "ecmaVersion": 2017,
+        "ecmaVersion": 14,
         "sourceType": "module",
         "ecmaFeatures": {
             "impliedStrict": true
@@ -10,7 +10,7 @@
     "env": {
         "browser": true,
         "webextensions": true,
-        "es6": true
+        "es2023": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/scripts/manifests/chromemanifest.json
+++ b/scripts/manifests/chromemanifest.json
@@ -9,8 +9,6 @@
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
   "browser_action": {
-    "browser_style": true,
-    "chrome_style": true,
     "default_icon": "icons/fa-grin-dark.png",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -28,13 +26,12 @@
   },
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true,
-    "chrome_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["browser-polyfill.js", "background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -9,7 +9,6 @@
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
   "browser_action": {
-    "browser_style": true,
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -27,12 +26,12 @@
   },
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -75,7 +74,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "awesome-emoji-picker@rugk.github.io",
-      "strict_min_version": "87.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -9,7 +9,6 @@
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
   "browser_action": {
-    "browser_style": true,
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -27,12 +26,12 @@
   },
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -74,7 +73,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "awesome-emoji-picker@rugk.github.io",
-      "strict_min_version": "87.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/scripts/manifests/thunderbirdmanifest.json
+++ b/scripts/manifests/thunderbirdmanifest.json
@@ -10,7 +10,6 @@
 
 
   "compose_action": {
-    "browser_style": true,
     "default_area": "formattoolbar",
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
@@ -25,12 +24,12 @@
   },
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "commands": {
     "_execute_compose_action": {
@@ -63,7 +62,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "awesome-emoji-picker@rugk.github.io",
-      "strict_min_version": "91.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/src/background/background.html
+++ b/src/background/background.html
@@ -7,7 +7,7 @@ See also https://discourse.mozilla.org/t/using-es6-modules-in-background-scripts
 	<head>
 		<meta charset="utf-8">
 		<!-- async currently disabled, because of https://bugzilla.mozilla.org/show_bug.cgi?id=1506464 -->
-		<script type="application/javascript" src="../browser-polyfill.js"></script>
+		<script src="../browser-polyfill.js" type="module"></script>
 		<script src="./modules/InstallUpgrade.js" type="module" charset="utf-8"></script>
 		<script async src="background.js" type="module" charset="utf-8"></script>
 	</head>

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -78,9 +78,7 @@ export async function init() {
 
     applySettings(contextMenu);
 
-    // IS_THUNDERBIRD should not have been needed after https://bugzilla.mozilla.org/show_bug.cgi?id=1681153
-    // Fixed in Thunderbird 99 by https://bugzilla.mozilla.org/show_bug.cgi?id=1751895
-    if (IS_THUNDERBIRD || IS_CHROME) {
+    if (IS_CHROME) {
         menus.onClicked.addListener(handle);
     }
 }

--- a/src/background/modules/OmniboxSearch.js
+++ b/src/background/modules/OmniboxSearch.js
@@ -50,13 +50,13 @@ function openTabUrl(url, disposition) {
     case "newForegroundTab":
         browser.tabs.create({
             active: true,
-            url: url
+            url
         });
         break;
     case "newBackgroundTab":
         browser.tabs.create({
             active: false,
-            url: url
+            url
         });
         break;
     }
@@ -123,7 +123,7 @@ export async function triggerOmnixboxDisabledSearch(text, disposition) {
         default: // eslint-disable-line no-fallthrough
             return browser.search.search({
                 query: text,
-                tabId: tabId
+                tabId
             });
         }
     }

--- a/src/common/modules/AutocorrectHandler.js
+++ b/src/common/modules/AutocorrectHandler.js
@@ -5,8 +5,8 @@ import * as BrowserCommunication from "/common/modules/BrowserCommunication/Brow
 
 import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunicationTypes.js";
 import * as symbols from "/common/modules/data/Symbols.js";
-// Not actually a module
-import * as emojimart from "/common/lib/emoji-mart-embed/dist/emoji-mart.js";
+// Not actually a module, but sets the emojiMart global
+import "/common/lib/emoji-mart-embed/dist/emoji-mart.js";
 
 const settings = {
     enabled: null,
@@ -223,11 +223,11 @@ function sendSettings(autocorrect) {
                     enabled: settings.enabled,
                     autocomplete: settings.autocomplete,
                     autocompleteSelect: settings.autocompleteSelect,
-                    autocorrections: autocorrections,
-                    longest: longest,
+                    autocorrections,
+                    longest,
                     symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
                     antipatterns: IS_CHROME ? antipatterns.source : antipatterns,
-                    emojiShortcodes: emojiShortcodes
+                    emojiShortcodes
                 }
             ).catch(onError);
         }
@@ -263,11 +263,11 @@ export async function init() {
                 enabled: settings.enabled,
                 autocomplete: settings.autocomplete,
                 autocompleteSelect: settings.autocompleteSelect,
-                autocorrections: autocorrections,
-                longest: longest,
+                autocorrections,
+                longest,
                 symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
                 antipatterns: IS_CHROME ? antipatterns.source : antipatterns,
-                emojiShortcodes: emojiShortcodes
+                emojiShortcodes
             };
             // console.log(response);
             return Promise.resolve(response);

--- a/src/common/modules/EmojiInteraction.js
+++ b/src/common/modules/EmojiInteraction.js
@@ -18,7 +18,7 @@ export async function insertOrCopy(text, options) {
         insertIntoPage,
         copyOnlyOnFallback
     } = options;
-    let copyToClipboard = options.copyToClipboard;
+    let { copyToClipboard } = options;
 
     console.log("Action triggered for emoji:", text);
 

--- a/src/common/modules/PageHandler.js
+++ b/src/common/modules/PageHandler.js
@@ -3,6 +3,8 @@
  *
  */
 
+import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunicationTypes.js";
+
 /**
  * Insert emoji into page.
  *
@@ -10,7 +12,7 @@
  *
  * @public
  * @param {string} text
- * @returns {Promise}
+ * @returns {Promise[]}
  */
 export async function insertIntoPage(text) {
     const tabs = await browser.tabs.query({
@@ -20,11 +22,9 @@ export async function insertIntoPage(text) {
 
     const promises = tabs.map((tab) => {
         // send request to insert emoji
-        // This will not work in Manifest V3: https://developer.chrome.com/docs/extensions/mv3/intro/mv3-migration/#executing-arbitrary-strings
-        return browser.tabs.executeScript(tab.id, {
-            code: `insertIntoPage(${JSON.stringify(text)});`,
-            allFrames: true,
-            runAt: "document_end"
+        return browser.tabs.sendMessage(tab.id, {
+            type: COMMUNICATION_MESSAGE_TYPE.INSERT,
+            text
         });
     });
 

--- a/src/common/modules/data/BrowserCommunicationTypes.js
+++ b/src/common/modules/data/BrowserCommunicationTypes.js
@@ -16,5 +16,6 @@ export const COMMUNICATION_MESSAGE_TYPE = Object.freeze({
     OMNIBAR_TOGGLE: "omnibarToggle",
     AUTOCORRECT_BACKGROUND: "autocorrectBackground",
     AUTOCORRECT_CONTENT: "autocorrectContent",
-    CONTEXT_MENU: "contextMenu"
+    CONTEXT_MENU: "contextMenu",
+    INSERT: "insert"
 });

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -3,6 +3,7 @@
 // communication type
 // directly include magic constant as a workaround as we cannot import modules in content scripts due to https://bugzilla.mozilla.org/show_bug.cgi?id=1451545
 const AUTOCORRECT_CONTENT = "autocorrectContent";
+const INSERT = "insert";
 
 let insertedText; // Last insert text
 let deletedText; // Last deleted text
@@ -316,28 +317,29 @@ function undoAutocorrect(event) {
  * @returns {void}
  */
 function handleResponse(message, sender) {
-    if (message.type !== AUTOCORRECT_CONTENT) {
-        return;
-    }
-    ({
-        enabled,
-        autocomplete,
-        autocompleteSelect,
-        autocorrections,
-        longest,
-        symbolpatterns,
-        antipatterns,
-        emojiShortcodes
-    } = message);
-    symbolpatterns = IS_CHROME ? new RegExp(symbolpatterns, "u") : symbolpatterns;
-    antipatterns = IS_CHROME ? new RegExp(antipatterns, "u") : antipatterns;
+    if (message.type === AUTOCORRECT_CONTENT) {
+        ({
+            enabled,
+            autocomplete,
+            autocompleteSelect,
+            autocorrections,
+            longest,
+            symbolpatterns,
+            antipatterns,
+            emojiShortcodes
+        } = message);
+        symbolpatterns = IS_CHROME ? new RegExp(symbolpatterns, "u") : symbolpatterns;
+        antipatterns = IS_CHROME ? new RegExp(antipatterns, "u") : antipatterns;
 
-    if (enabled) {
-        addEventListener("beforeinput", undoAutocorrect, true);
-        addEventListener("beforeinput", autocorrect, true);
-    } else {
-        removeEventListener("beforeinput", undoAutocorrect, true);
-        removeEventListener("beforeinput", autocorrect, true);
+        if (enabled) {
+            addEventListener("beforeinput", undoAutocorrect, true);
+            addEventListener("beforeinput", autocorrect, true);
+        } else {
+            removeEventListener("beforeinput", undoAutocorrect, true);
+            removeEventListener("beforeinput", autocorrect, true);
+        }
+    } else if (message.type === INSERT) {
+        insertIntoPage(message.text);
     }
 }
 

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -9,7 +9,6 @@
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
   "browser_action": {
-    "browser_style": true,
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -27,12 +26,12 @@
   },
 
   "options_ui": {
-    "page": "options/options.html",
-    "browser_style": true
+    "page": "options/options.html"
   },
 
   "background": {
-    "page": "background/background.html"
+    "scripts": ["background/modules/InstallUpgrade.js", "background/background.js"],
+    "type": "module"
   },
   "content_scripts": [
     {
@@ -75,7 +74,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "awesome-emoji-picker@rugk.github.io",
-      "strict_min_version": "87.0"
+      "strict_min_version": "112.0"
     }
   }
 }

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -115,7 +115,7 @@ function applyAutocorrectPermissions(optionValue, option, event) {
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND,
-        optionValue: optionValue
+        optionValue
     });
 
     return retPromise;
@@ -134,7 +134,7 @@ function applyContextMenuSettings(optionValue, option, event) {
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.CONTEXT_MENU,
-        optionValue: optionValue
+        optionValue
     });
 }
 

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -6,7 +6,7 @@
 		<link rel="stylesheet" href="../common/common.css">
 		<link rel="stylesheet" href="options.css">
 
-		<script type="application/javascript" src="../browser-polyfill.js"></script>
+		<script src="../browser-polyfill.js" type="module"></script>
 		<script async src="./fastLoad.js" type="module"></script>
   		<script defer src="../common/common.js" type="module"></script>
 		<script defer src="./options.js" type="module"></script>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -7,7 +7,7 @@
 		<link rel="stylesheet" href="/common/lib/emoji-mart-embed/dist/emoji-mart.css">
 		<link rel="stylesheet" href="index.css"> <!-- load later then emoji-mart so overwriting is possible -->
 
-		<script type="application/javascript" src="../browser-polyfill.js"></script>
+		<script src="../browser-polyfill.js" type="module"></script>
 		<script defer src="../common/common.js" type="module" charset="utf-8"></script>
 		<script defer src="index.js" type="module" charset="utf-8"></script>
 		<!-- we need to load emoji-mart last, so autoFocus works -->

--- a/src/popup/index.js
+++ b/src/popup/index.js
@@ -46,7 +46,9 @@ async function createPicker() {
  * @returns {Promise}
  */
 export async function focusElement(element, retries = 20, delay = 50) {
-    const wait = (ms) => new Promise((func) => setTimeout(func, ms));
+    const wait = (ms) => new Promise((func) => {
+        setTimeout(func, ms);
+    });
 
     element.focus();
 


### PR DESCRIPTION
* Removed use of `tabs.executeScript()` (required for MV3)
* Updated manifest files:
  * Removed use of `browser_style: true` (required for MV3, see: https://github.com/TinyWebEx/CommonCss/issues/4)
  * Use background scripts instead of a background page (requires Firefox/Thunderbird 112 or greater)
* Updated ESLint version:
  * Made minor ESLint fixes enabling additional rules (see: https://github.com/TinyWebEx/AddonTemplate/issues/6).