### PR TITLE
docs; explain how to contribute emoji (picker) translations upstream

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ For more details, [see the official docs](https://developer.mozilla.org/Add-ons/
 ### Translating emoji (picker) terms itself (categories, skin names etc.)
 The translations for many emoji terms or most of the picker GUI is actually [managed upstream by the library we use here](https://github.com/missive/emoji-mart/tree/main?tab=readme-ov-file#-internationalization). It is integrated here and will be used when the library is updated the next time here.
 
-Thus, we advise you to contribute your translations/improvments or other localisation data there. As a pointer, the directory is this one here: https://github.com/missive/emoji-mart/tree/main/packages/emoji-mart-data/i18n
+Thus, we advise you to contribute your translations/improvements or other localization data there. As a pointer, the directory is this one here: https://github.com/missive/emoji-mart/tree/main/packages/emoji-mart-data/i18n
 You'll find a simple JSON to use for your translation there. You can just create a PR there.
 
 ### Other items to translate


### PR DESCRIPTION
In https://github.com/missive/emoji-mart/tree/main?tab=readme-ov-file#-internationalization I've removed the outdated docs, but did not consider writing new ones, so this bridges a gap here.