### PR TITLE
Manifest v3

### DIFF
--- a/scripts/manifests/chrome.json
+++ b/scripts/manifests/chrome.json
@@ -30,12 +30,7 @@
   },
 
   "background": {
-    "scripts": [
-      "background/modules/InstallUpgrade.js",
-      "background/modules/ContextMenu.js",
-      "background/modules/OmniboxSearch.js",
-      "background/init.js"
-    ],
+    "service_worker": "background/chromeServiceWorker.js",
     "type": "module"
   },
 
@@ -43,9 +38,7 @@
     {
       "matches": ["<all_urls>"],
       "all_frames": true,
-      "js": [
-        "content_scripts/autocorrect.js"
-      ]
+      "js": ["content_scripts/autocorrect.js"]
     }
   ],
   "commands": {
@@ -70,11 +63,12 @@
   "permissions": [
     "storage",
     "activeTab",
-    "tabs",
     "contextMenus"
   ],
 
   "optional_permissions": [
-    "clipboardWrite"
+    "clipboardWrite",
+    "search",
+    "tabs"
   ]
 }

--- a/scripts/manifests/chrome.json
+++ b/scripts/manifests/chrome.json
@@ -44,7 +44,6 @@
       "matches": ["<all_urls>"],
       "all_frames": true,
       "js": [
-        "browser-polyfill.js",
         "content_scripts/autocorrect.js"
       ]
     }

--- a/scripts/manifests/chrome.json
+++ b/scripts/manifests/chrome.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
   "version": "3.0.1",
@@ -8,7 +8,7 @@
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
-  "browser_action": {
+  "action": {
     "default_icon": "icons/fa-grin-dark.png",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -36,8 +36,7 @@
       "background/modules/OmniboxSearch.js",
       "background/init.js"
     ],
-    "type": "module",
-    "persistent": true
+    "type": "module"
   },
 
   "content_scripts": [
@@ -51,7 +50,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+Period"
       },
@@ -59,8 +58,9 @@
     }
   },
 
-  // testing version allows loading unit test libraries from CDNs
-  "content_security_policy": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
+  },
   "icons": {
     "32": "icons/icon_32.png",
     "64": "icons/icon_64.png",
@@ -78,5 +78,4 @@
   "optional_permissions": [
     "clipboardWrite"
   ]
-  // "search" currently not requested though, see https://discourse.mozilla.org/t/why-do-we-need-an-extra-permission-simply-for-starting-a-search/41174?u=rugkx
 }

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -55,9 +55,8 @@
     }
   },
 
-  // testing version allows loading unit test libraries from CDNs
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com"
+    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
   },
   "icons": {
     "32": "icons/icon_32.png",

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "AwesomeEmojiPicker DEV VERSION",
   "short_name": "__MSG_extensionNameShort__",
   "version": "3.0.1",
@@ -8,7 +8,7 @@
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
-  "browser_action": {
+  "action": {
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -36,8 +36,7 @@
       "background/modules/OmniboxSearch.js",
       "background/init.js"
     ],
-    "type": "module",
-    "persistent": true
+    "type": "module"
   },
 
   "content_scripts": [
@@ -48,7 +47,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+Period"
       },
@@ -57,7 +56,9 @@
   },
 
   // testing version allows loading unit test libraries from CDNs
-  "content_security_policy": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com"
+  },
   "icons": {
     "32": "icons/icon_32.png",
     "64": "icons/icon_64.png",

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
   "version": "3.0.1",
@@ -8,7 +8,7 @@
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
-  "browser_action": {
+  "action": {
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -36,8 +36,7 @@
       "background/modules/OmniboxSearch.js",
       "background/init.js"
     ],
-    "type": "module",
-    "persistent": true
+    "type": "module"
   },
 
   "content_scripts": [
@@ -48,7 +47,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+Period"
       },
@@ -56,7 +55,9 @@
     }
   },
 
-  "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
+  },
   "icons": {
     "32": "icons/icon_32.png",
     "64": "icons/icon_64.png",
@@ -75,7 +76,6 @@
     "search",
     "tabs"
   ],
-  // "search" currently not requested though, see https://discourse.mozilla.org/t/why-do-we-need-an-extra-permission-simply-for-starting-a-search/41174?u=rugkx
 
   "browser_specific_settings": {
     "gecko": {

--- a/scripts/manifests/thunderbird.json
+++ b/scripts/manifests/thunderbird.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "__MSG_extensionName__",
   "short_name": "__MSG_extensionNameShort__",
   "version": "3.0.2",
@@ -34,8 +34,7 @@
       "background/modules/OmniboxSearch.js",
       "background/init.js"
     ],
-    "type": "module",
-    "persistent": true
+    "type": "module"
   },
 
   "commands": {
@@ -47,7 +46,9 @@
     }
   },
 
-  "content_security_policy": "default-src 'self'; style-src 'self' 'unsafe-inline'",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
+  },
   "icons": {
     "32": "icons/icon_32.png",
     "64": "icons/icon_64.png",

--- a/src/background/chromeServiceWorker.js
+++ b/src/background/chromeServiceWorker.js
@@ -1,0 +1,4 @@
+import "./modules/InstallUpgrade.js";
+import "./modules/ContextMenu.js";
+import "./modules/OmniboxSearch.js";
+import "./init.js";

--- a/src/background/init.js
+++ b/src/background/init.js
@@ -4,7 +4,9 @@ import * as ContextMenu from "./modules/ContextMenu.js";
 
 IconHandler.init();
 AutocorrectHandler.init();
-ContextMenu.init();
+
+browser.runtime.onInstalled.addListener(async () => {
+    await ContextMenu.init();
+});
 
 console.warn("background: init loaded");
-

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -1,3 +1,4 @@
+import { isChrome } from "../../common/BrowserCompat.js";
 import * as AddonSettings from "/common/modules/AddonSettings/AddonSettings.js";
 import * as BrowserCommunication from "/common/modules/BrowserCommunication/BrowserCommunication.js";
 import { isMobile } from "/common/modules/MobileHelper.js";
@@ -7,7 +8,7 @@ import { COMMUNICATION_MESSAGE_TYPE } from "/common/modules/data/BrowserCommunic
 const IS_THUNDERBIRD = Boolean(globalThis.messenger);
 
 // Chrome
-const IS_CHROME = Object.getPrototypeOf(browser) !== Object.prototype;
+const IS_CHROME = isChrome();
 
 /**
  * hardcoded in manifest.json

--- a/src/background/modules/ContextMenu.js
+++ b/src/background/modules/ContextMenu.js
@@ -27,7 +27,7 @@ function handle(info, _tab) {
     if (info.menuItemId === TRIGGER_KEYWORD) {
         // Thunderbird
         // Not yet enabled by Chrome: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/openPopup#browser_compatibility
-        (IS_THUNDERBIRD ? browser.composeAction : browser.browserAction).openPopup();
+        (IS_THUNDERBIRD ? browser.composeAction : browser.action).openPopup();
     }
 }
 
@@ -43,7 +43,7 @@ async function applySettings(contextMenu) {
     if (contextMenu.insertEmoji) {
         // find command
         const allCommands = await browser.commands.getAll();
-        const commandToFind = IS_THUNDERBIRD ? "_execute_compose_action" : "_execute_browser_action";
+        const commandToFind = IS_THUNDERBIRD ? "_execute_compose_action" : "_execute_action";
         const popupOpenCommand = allCommands.find((command) => command.name === commandToFind);
 
         const menuText = `${popupOpenCommand.description || "Insert Emoji"} (${popupOpenCommand.shortcut})`;

--- a/src/background/modules/OmniboxSearch.js
+++ b/src/background/modules/OmniboxSearch.js
@@ -218,7 +218,7 @@ export async function triggerOmnixboxSearch(text, disposition) {
         // otherwise open popup to show all emoji choices
         // does not work, because we have no permission
         // see https://bugzilla.mozilla.org/show_bug.cgi?id=1542358
-        // browser.browserAction.openPopup();
+        // browser.action.openPopup();
 
         // search for result in emojipedia
         const resultUrl = `https://emojipedia.org/search/?${new URLSearchParams({ q: text })}`;

--- a/src/common/BrowserCompat.js
+++ b/src/common/BrowserCompat.js
@@ -1,0 +1,12 @@
+/**
+ * Check if the current browser is Chrome/Chromium.
+ *
+ * @returns {boolean}
+ */
+export function isChrome() {
+    return (
+        navigator.userAgentData?.brands.find(
+            ({ brand }) => brand.toLowerCase() === "chromium"
+        ) !== undefined
+    );
+}

--- a/src/common/modules/AutocorrectHandler.js
+++ b/src/common/modules/AutocorrectHandler.js
@@ -1,5 +1,6 @@
 "use strict";
 
+import { isChrome } from "../BrowserCompat.js";
 import { getEmojiMartInitialisationData } from "./EmojiMartInitialisationData.js";
 import * as AddonSettings from "/common/modules/AddonSettings/AddonSettings.js";
 import * as BrowserCommunication from "/common/modules/BrowserCommunication/BrowserCommunication.js";
@@ -31,8 +32,7 @@ let antipatterns = null;
 const emojiShortcodes = {};
 
 // Chrome
-// Adapted from: https://github.com/mozilla/webextension-polyfill/blob/master/src/browser-polyfill.js
-const IS_CHROME = Object.getPrototypeOf(browser) !== Object.prototype;
+const IS_CHROME = isChrome();
 
 /**
  * Traverse Trie tree of objects to create RegEx.

--- a/src/common/modules/AutocorrectHandler.js
+++ b/src/common/modules/AutocorrectHandler.js
@@ -22,9 +22,11 @@ let autocorrections = {};
 // Longest autocorrection
 let longest = 0;
 
-let symbolpatterns = [];
+/* @type {RegExp|null} */
+let symbolpatterns = null;
 // Exceptions, do not autocorrect for these patterns
-let antipatterns = [];
+/* @type {RegExp|null} */
+let antipatterns = null;
 
 const emojiShortcodes = {};
 
@@ -35,7 +37,7 @@ const IS_CHROME = Object.getPrototypeOf(browser) !== Object.prototype;
 /**
  * Traverse Trie tree of objects to create RegEx.
  *
- * @param {Object.<string, Object|boolean>} tree
+ * @param {Object.<string, object | boolean>} tree
  * @returns {string}
  */
 function createRegEx(tree) {
@@ -109,10 +111,15 @@ function createTree(arr) {
 /**
  * Apply new autocorrect settings and create regular expressions.
  *
- * @returns {void}
+ * @param {boolean} forceRebuild whether to force rebuild of the autocorrect RegExp patterns
+ * @returns {Promise<void>}
  */
-function applySettings() {
+async function applySettings(forceRebuild) {
     const start = performance.now();
+
+    let symbolpatternsRegexpString = "";
+    let antipatternsRegexpString = "";
+
     autocorrections = {};
 
     // Add all symbols to our autocorrections map, we want to replace
@@ -124,73 +131,74 @@ function applySettings() {
     }
 
     // Longest autocorrection
-    longest = 0;
-
-    for (const symbol in autocorrections) {
-        if (symbol.length > longest) {
-            longest = symbol.length;
-        }
-    }
+    longest = Math.max(...Object.keys(autocorrections).map((s) => s.length), 0);
     console.log("Longest autocorrection", longest);
 
-    symbolpatterns = createTree(Object.keys(autocorrections));
+    if (!forceRebuild) {
+        const cachedRegexpStrings = await browser.storage.session.get({
+            symbolpatternsRegexpString: "",
+            antipatternsRegexpString: ""
+        });
+        symbolpatternsRegexpString = cachedRegexpStrings.symbolpatternsRegexpString;
+        antipatternsRegexpString = cachedRegexpStrings.antipatternsRegexpString;
+    }
 
-    // Do not autocorrect for these patterns
-    antipatterns = [];
-    for (const x in autocorrections) {
-        let length = 0;
-        let index = x.length;
+    if (!symbolpatternsRegexpString || !antipatternsRegexpString) {
+        console.log("Building autocorrect RegExp patterns");
+        // Do not autocorrect for these patterns
+        let antipatternsList = [];
+        for (const x in autocorrections) {
+            let length = 0;
+            let index = x.length;
 
-        for (const y in autocorrections) {
-            if (x === y) {
-                continue;
+            for (const y in autocorrections) {
+                if (x === y) {
+                    continue;
+                }
+                const aindex = x.indexOf(y);
+                if (aindex !== -1) {
+                    if (aindex < index) {
+                        index = aindex;
+                        length = y.length;
+                    } else if (aindex === index && y.length > length) {
+                        length = y.length;
+                    }
+                }
             }
-            const aindex = x.indexOf(y);
-            if (aindex !== -1) {
-                if (aindex < index) {
-                    index = aindex;
-                    length = y.length;
-                } else if (aindex === index && y.length > length) {
-                    length = y.length;
+
+            if (length) {
+                length = x.length - (index + length);
+                if (length > 1) {
+                    antipatternsList.push(x.slice(0, -(length - 1)));
                 }
             }
         }
+        antipatternsList = antipatternsList.filter((item, pos) => antipatternsList.indexOf(item) === pos);
+        console.log("Do not autocorrect for these patterns", antipatternsList);
 
-        if (length) {
-            length = x.length - (index + length);
-            if (length > 1) {
-                antipatterns.push(x.slice(0, -(length - 1)));
-            }
-        }
+        symbolpatternsRegexpString = createTree(Object.keys(autocorrections));
+        antipatternsRegexpString = createTree(antipatternsList);
+        await browser.storage.session.set({
+            symbolpatternsRegexpString,
+            antipatternsRegexpString
+        });
     }
-    antipatterns = antipatterns.filter((item, pos) => antipatterns.indexOf(item) === pos);
-    console.log("Do not autocorrect for these patterns", antipatterns);
 
-    antipatterns = createTree(antipatterns);
+    symbolpatterns = new RegExp(`(${symbolpatternsRegexpString})$`, "u");
+    antipatterns = new RegExp(`(${antipatternsRegexpString})$`, "u");
 
-    symbolpatterns = new RegExp(`(${symbolpatterns})$`, "u");
-    antipatterns = new RegExp(`(${antipatterns})$`, "u");
     const end = performance.now();
     console.log(`The new autocorrect settings were applied in ${end - start} ms.`);
 }
 
 /**
- * On error.
- *
- * @param {string} error
- * @returns {void}
- */
-function onError(error) {
-    console.error(`Error: ${error}`);
-}
-
-/**
  * Set autocorrect settings.
  *
- * @param {Object} autocorrect
- * @returns {void}
+ * @param {object} autocorrect
+ * @param {boolean} [modified] whether settings were modified (true) or loaded from storage (false)
+ * @returns {Promise<void>}
  */
-function setSettings(autocorrect) {
+async function setSettings(autocorrect, modified = true) {
     settings.enabled = autocorrect.enabled;
     settings.autocorrectEmojis = autocorrect.autocorrectEmojis;
     settings.autocorrectEmojiShortcodes = autocorrect.autocorrectEmojiShortcodes;
@@ -198,37 +206,47 @@ function setSettings(autocorrect) {
     settings.autocompleteSelect = autocorrect.autocompleteSelect;
 
     if (settings.enabled) {
-        applySettings();
+        await applySettings(/* forceRebuild= */ modified);
     }
 }
 
 /**
  * Send autocorrect settings to content scripts.
  *
- * @param {Object} autocorrect
- * @returns {void}
+ * @param {object} autocorrect
+ * @returns {Promise<void>}
  */
-function sendSettings(autocorrect) {
-    setSettings(autocorrect);
+async function sendSettings(autocorrect) {
+    await setSettings(autocorrect, /* modified= */ true);
 
-    browser.tabs.query({}).then((tabs) => {
+    try {
+        const tabs = await browser.tabs.query({});
         for (const tab of tabs) {
-            browser.tabs.sendMessage(
-                tab.id,
-                {
-                    type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_CONTENT,
-                    enabled: settings.enabled,
-                    autocomplete: settings.autocomplete,
-                    autocompleteSelect: settings.autocompleteSelect,
-                    autocorrections,
-                    longest,
-                    symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
-                    antipatterns: IS_CHROME ? antipatterns.source : antipatterns,
-                    emojiShortcodes
-                }
-            ).catch(onError);
+            if (!tab.id) {
+                continue;
+            }
+            try {
+                await browser.tabs.sendMessage(
+                    tab.id,
+                    {
+                        type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_CONTENT,
+                        enabled: settings.enabled,
+                        autocomplete: settings.autocomplete,
+                        autocompleteSelect: settings.autocompleteSelect,
+                        autocorrections,
+                        longest,
+                        symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
+                        antipatterns: IS_CHROME ? antipatterns.source : antipatterns,
+                        emojiShortcodes
+                    }
+                );
+            } catch (error) {
+                console.error(`Error sending autocorrect settings to tab ${tab.id}:`, error);
+            }
         }
-    }).catch(onError);
+    } catch (error) {
+        console.error("Error querying tabs:", error);
+    }
 }
 
 /**
@@ -252,7 +270,7 @@ export async function init() {
     Object.freeze(emojiShortcodes);
     console.debug("Emoji shortcodes:", emojiShortcodes);
 
-    setSettings(autocorrect);
+    await setSettings(autocorrect, /* modified= */ false);
 
     // Thunderbird
     // Cannot register scripts in manifest.json file: https://bugzilla.mozilla.org/show_bug.cgi?id=1902843
@@ -265,7 +283,7 @@ export async function init() {
     }
 }
 
-BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND, (request) => {
+BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND, async (request) => {
     // clear cache by reloading all options
     // await AddonSettings.loadOptions();
 

--- a/src/common/modules/IconHandler.js
+++ b/src/common/modules/IconHandler.js
@@ -23,7 +23,7 @@ function setPopupIcon(icon) {
     }
 
     // Thunderbird
-    const browserAction = globalThis.messenger ? browser.composeAction : browser.browserAction;
+    const browserAction = globalThis.messenger ? browser.composeAction : browser.action;
 
     // ignore request if API is not available
     if (!browserAction.setIcon) {

--- a/src/common/modules/data/Tips.js
+++ b/src/common/modules/data/Tips.js
@@ -131,7 +131,7 @@ const tipArray = [
 
             // find command
             const allCommands = await browser.commands.getAll();
-            const commandToFind = IS_THUNDERBIRD ? "_execute_compose_action" : "_execute_browser_action";
+            const commandToFind = IS_THUNDERBIRD ? "_execute_compose_action" : "_execute_action";
             const popupOpenCommand = allCommands.find((command) => command.name === commandToFind);
 
             // if shortcut is modified, do not show tip

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -29,10 +29,6 @@ let emojiShortcodes = {};
 
 let running = false;
 
-// Chrome
-// Adapted from: https://github.com/mozilla/webextension-polyfill/blob/master/src/browser-polyfill.js
-const IS_CHROME = Object.getPrototypeOf(browser) !== Object.prototype;
-
 /**
  * Get caret position.
  *
@@ -324,8 +320,8 @@ function handleResponse(message, sender) {
             antipatterns,
             emojiShortcodes
         } = message);
-        symbolpatterns = IS_CHROME ? new RegExp(symbolpatterns, "u") : symbolpatterns;
-        antipatterns = IS_CHROME ? new RegExp(antipatterns, "u") : antipatterns;
+        symbolpatterns = (typeof symbolpatterns === "string") ? new RegExp(symbolpatterns, "u") : symbolpatterns;
+        antipatterns = (typeof antipatterns === "string") ? new RegExp(antipatterns, "u") : antipatterns;
 
         if (enabled) {
             addEventListener("beforeinput", undoAutocorrect, true);

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -55,9 +55,8 @@
     }
   },
 
-  // testing version allows loading unit test libraries from CDNs
   "content_security_policy": {
-    "extension_pages": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com"
+    "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
   },
   "icons": {
     "32": "icons/icon_32.png",

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,5 +1,5 @@
 {
-  "manifest_version": 2,
+  "manifest_version": 3,
   "name": "AwesomeEmojiPicker DEV VERSION",
   "short_name": "__MSG_extensionNameShort__",
   "version": "3.0.1",
@@ -8,7 +8,7 @@
   "description": "__MSG_extensionDescription__",
   "homepage_url": "https://github.com/rugk/awesome-emoji-picker",
 
-  "browser_action": {
+  "action": {
     "default_icon": "icons/fa-grin-dark.svg",
     "default_title": "__MSG_browserActionButtonTitle__",
     "default_popup": "popup/index.html",
@@ -36,8 +36,7 @@
       "background/modules/OmniboxSearch.js",
       "background/init.js"
     ],
-    "type": "module",
-    "persistent": true
+    "type": "module"
   },
 
   "content_scripts": [
@@ -48,7 +47,7 @@
     }
   ],
   "commands": {
-    "_execute_browser_action": {
+    "_execute_action": {
       "suggested_key": {
         "default": "Ctrl+Shift+Period"
       },
@@ -57,7 +56,9 @@
   },
 
   // testing version allows loading unit test libraries from CDNs
-  "content_security_policy": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com",
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; img-src data:; style-src 'self' 'unsafe-inline' https://unpkg.com; script-src 'self' https://unpkg.com"
+  },
   "icons": {
     "32": "icons/icon_32.png",
     "64": "icons/icon_64.png",

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -6,7 +6,6 @@
 		<link rel="stylesheet" href="../common/common.css">
 		<link rel="stylesheet" href="options.css">
 
-		<script src="../browser-polyfill.js" type="module"></script>
 		<script async src="./fastLoad.js" type="module"></script>
   		<script defer src="../common/common.js" type="module"></script>
 		<script defer src="./options.js" type="module"></script>

--- a/src/popup/index.html
+++ b/src/popup/index.html
@@ -6,7 +6,6 @@
 		<link rel="stylesheet" href="../common/common.css">
 		<link rel="stylesheet" href="index.css"> <!-- load later then emoji-mart so overwriting is possible -->
 
-		<script src="../browser-polyfill.js" type="module"></script>
 		<script defer src="../common/common.js" type="module" charset="utf-8"></script>
 		<script defer src="index.js" type="module" charset="utf-8"></script>
 	</head>


### PR DESCRIPTION
Fixes #68 

Based on the [migration checklist](https://extensionworkshop.com/documentation/develop/manifest-v3-migration-guide/#migration-checklist) in extensionworkshop:

> - [x] Update the manifest.json key manifest_version to 3.
>   - Done
> - [ ] If your extension adds a search engine, add a local icon and reference it in the manifest.json key chrome_settings_overrides.search_provider.favicon_url.
>   - Not sure if this is relevant?
> - [ ] Remove any host permissions from the manifest.json keys permissions and optional_permissions and add them to the host_permissions key. Remember that host_permissions is treated as an optional permission in Firefox and Safari but granted at install in Chrome.
>   - Followup needed to resolve [edit: later - to not trigger auto-close on GitHub] #171
> - [x] Remove references to browser_style from the manifest.json keys browser_action, options_ui, page_action, and sidebar_action.
>   - Not used
> - [x] If browser_style:false was not specified in options_ui and sidebar_action, confirm that their appearance has not changed.
>   - Not used
> - [x] Rename the manifest.json key browser_action to action and update any API references from browser.browserAction to browser.action.
>   - Done
> - [x] Convert background pages to be non-persistent.
>   - Done. Removed `"persistent": true` from manifest files, seems like all the code was already event driven as it is
> - [x] Move the extension’s CSP to the manifest.json key content_security_policy.extension_pages and update the CSP to conform to Manifest V3 requirements.
>   - Done
> - [x] Move any arbitrary strings executed as scripts to files and update your code to use the Scripting API.
>   - Not used
> - [x] Rename the deprecated manifest.json key applications to browser_specific_settings.
>   - Not used
> - [x] The add-on ID is required to publish your extension. Make sure to add one in the manifest.json key browser_specific_settings.gecko.id.
>   - Already resolved
> - [x] Ensure that the top-level manifest.json key version is a string of numbers separated by up to 3 dots. For details, see [version format](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/version/format).
>   - Already resolved

Note that tests are broken now, because with Manifest v3 even a temporary extension can't set the CSP to external resources. One option is to add the dependencies to package.json and import directly from node_modules (the tests are pretty useless though, so I skipped that part for now)

I manually ran through the extension, trying every feature I could think of. Everything seems to work as before (the only issue I could find is that copy-as-`:colon:` doesn't work, but that seems to be broken already)