### PR TITLE
Disable Codacy result upload

### DIFF
--- a/.github/workflows/codacy-analysis.yml
+++ b/.github/workflows/codacy-analysis.yml
@@ -41,8 +41,9 @@ jobs:
           # This will handover control about PR rejection to the GitHub side
           max-allowed-issues: 2147483647
 
+      # disabled due to: https://github.com/codacy/codacy-analysis-cli-action/issues/142
       # Upload the SARIF file generated in the previous step
-      - name: Upload SARIF results file
-        uses: github/codeql-action/upload-sarif@v1
-        with:
-          sarif_file: results.sarif
+      #- name: Upload SARIF results file
+      #  uses: github/codeql-action/upload-sarif@v1
+      #  with:
+      #    sarif_file: results.sarif


### PR DESCRIPTION
Due to a bug there: https://github.com/codacy/codacy-analysis-cli-action/issues/142

Fixes https://github.com/rugk/awesome-emoji-picker/issues/177, but should be reverted later.