### PR TITLE
fix: fix import for isChrome() fixing options page

### DIFF
--- a/src/options/modules/ManualAdjustments.js
+++ b/src/options/modules/ManualAdjustments.js
@@ -1,4 +1,24 @@
 import { getBrowserValue } from "/common/modules/BrowserCompat/BrowserCompat.js";
+import { isChrome } from "/common/modules/BrowserCompat/BrowserCompat.js";
+
+
+function addShortcutsLink() {
+    document.getElementById("shortcut").addEventListener("click", async (event) => {
+        event.target.disabled = true;
+
+        if (browser.commands.openShortcutSettings) {
+            browser.commands.openShortcutSettings().finally(() => {
+                event.target.disabled = false;
+            });
+        } else if (await isChrome()) {
+            browser.tabs.create({ url: "chrome://extensions/shortcuts" }).finally(() => {
+                event.target.disabled = false;
+            });
+        } else {
+            alert("Unable to automatically open the Shortcut Settings (requires Firefox or Thunderbird 137 or greater).");
+        }
+    });
+}
 
 /**
  * Initializes module.
@@ -15,4 +35,7 @@ export function init() {
     }).then((browserUrl) => {
         document.getElementById("link-unicodify").href = browserUrl;
     });
+
+    addShortcutsLink();
 }
+

--- a/src/options/modules/ManualAdjustments.js
+++ b/src/options/modules/ManualAdjustments.js
@@ -1,7 +1,9 @@
 import { getBrowserValue } from "/common/modules/BrowserCompat/BrowserCompat.js";
 import { isChrome } from "/common/modules/BrowserCompat/BrowserCompat.js";
 
-
+/**
+ * Adds a "link"/trigger to the shortcut option so that it opens.
+ */
 function addShortcutsLink() {
     document.getElementById("shortcut").addEventListener("click", async (event) => {
         event.target.disabled = true;

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -5,31 +5,12 @@
  */
 
 import { tips } from "/common/modules/data/Tips.js";
-import { isChrome } from "/common/modules/BrowserCompat/BrowserCompat.js";
 import * as RandomTips from "/common/modules/RandomTips/RandomTips.js";
 import * as AddonSettings from "/common/modules/AddonSettings/AddonSettings.js";
 import * as AutomaticSettings from "/common/modules/AutomaticSettings/AutomaticSettings.js";
 import * as CustomOptionTriggers from "./modules/CustomOptionTriggers.js";
 import * as ColorSchemeModeHelper from "./modules/ColorSchemeModeHelper.js";
 import * as ManualAdjustments from "./modules/ManualAdjustments.js";
-
-// Chrome
-
-document.getElementById("shortcut").addEventListener("click", async (event) => {
-    event.target.disabled = true;
-
-    if (browser.commands.openShortcutSettings) {
-        browser.commands.openShortcutSettings().finally(() => {
-            event.target.disabled = false;
-        });
-    } else if (await isChrome()) {
-        browser.tabs.create({ url: "chrome://extensions/shortcuts" }).finally(() => {
-            event.target.disabled = false;
-        });
-    } else {
-        alert("Unable to automatically open the Shortcut Settings (requires Firefox or Thunderbird 137 or greater).");
-    }
-});
 
 // init modules
 CustomOptionTriggers.registerTrigger().then(() => {

--- a/src/options/options.js
+++ b/src/options/options.js
@@ -5,8 +5,7 @@
  */
 
 import { tips } from "/common/modules/data/Tips.js";
-
-import { isChrome } from "/common/BrowserCompat.js";
+import { isChrome } from "/common/modules/BrowserCompat/BrowserCompat.js";
 import * as RandomTips from "/common/modules/RandomTips/RandomTips.js";
 import * as AddonSettings from "/common/modules/AddonSettings/AddonSettings.js";
 import * as AutomaticSettings from "/common/modules/AutomaticSettings/AutomaticSettings.js";
@@ -15,16 +14,15 @@ import * as ColorSchemeModeHelper from "./modules/ColorSchemeModeHelper.js";
 import * as ManualAdjustments from "./modules/ManualAdjustments.js";
 
 // Chrome
-const IS_CHROME = await isChrome();
 
-document.getElementById("shortcut").addEventListener("click", (event) => {
+document.getElementById("shortcut").addEventListener("click", async (event) => {
     event.target.disabled = true;
 
     if (browser.commands.openShortcutSettings) {
         browser.commands.openShortcutSettings().finally(() => {
             event.target.disabled = false;
         });
-    } else if (IS_CHROME) {
+    } else if (await isChrome()) {
         browser.tabs.create({ url: "chrome://extensions/shortcuts" }).finally(() => {
             event.target.disabled = false;
         });


### PR DESCRIPTION
@tdulcet This fixes the issue introduced in https://github.com/rugk/awesome-emoji-picker/pull/184/changes/a7d66c096c4dee2879688b6f66be02c453ee6020 that broke the options page.

* `await` is not supported in top-level (CommonJS according to linting, it says) modules
* also the import path was wrong, which results i hard to detect errors


I should have tested this better…