### PR TITLE
docs: update Chrome Web Store URLs to new domain

### DIFF
--- a/src/common/modules/data/Tips.js
+++ b/src/common/modules/data/Tips.js
@@ -111,7 +111,7 @@ const tipArray = [
             tipSpec.actionButton.action = await getBrowserValue({
                 firefox: "https://addons.mozilla.org/firefox/addon/awesome-emoji-picker/reviews/?utm_source=addon-tips&utm_medium=addon&utm_content=addon-tips-tipYouLikeAddon&utm_campaign=addon-tips",
                 thunderbird: "https://addons.thunderbird.net/thunderbird/addon/awesome-emoji-picker/reviews/?utm_source=addon-tips&utm_medium=addon&utm_content=addon-tips-tipYouLikeAddon&utm_campaign=addon-tips",
-                chrome: "https://chrome.google.com/webstore/detail/awesome-emoji-picker/reviews/?utm_source=addon-tips&utm_medium=addon&utm_content=addon-tips-tipYouLikeAddon&utm_campaign=addon-tips"
+                chrome: "https://chromewebstore.google.com/detail/awesome-emoji-picker/reviews/?utm_source=addon-tips&utm_medium=addon&utm_content=addon-tips-tipYouLikeAddon&utm_campaign=addon-tips"
             });
             return null;
         }

--- a/src/options/modules/ManualAdjustments.js
+++ b/src/options/modules/ManualAdjustments.js
@@ -33,7 +33,7 @@ export function init() {
     getBrowserValue({
         firefox: "https://addons.mozilla.org/firefox/addon/unicodify-text-transformer/?utm_source=awesomeEmojiPicker-addon&utm_medium=addon&utm_content=awesomeEmojiPicker-addon-settings-inline&utm_campaign=awesomeEmojiPicker-addon-settings-inline",
         thunderbird: "https://addons.thunderbird.net/thunderbird/addon/unicodify-text-transformer/?utm_source=awesomeEmojiPicker-addon&utm_medium=addon&utm_content=awesomeEmojiPicker-addon-settings-inline&utm_campaign=awesomeEmojiPicker-addon-settings-inline",
-        chrome: "https://chrome.google.com/webstore/detail/unicodify-text-transformer/?utm_source=awesomeEmojiPicker-addon&utm_medium=addon&utm_content=awesomeEmojiPicker-addon-settings-inline&utm_campaign=awesomeEmojiPicker-addon-settings-inline"
+        chrome: "https://chromewebstore.google.com/detail/unicodify-text-transformer/?utm_source=awesomeEmojiPicker-addon&utm_medium=addon&utm_content=awesomeEmojiPicker-addon-settings-inline&utm_campaign=awesomeEmojiPicker-addon-settings-inline"
     }).then((browserUrl) => {
         document.getElementById("link-unicodify").href = browserUrl;
     });


### PR DESCRIPTION
Google has migrated the Chrome Web Store from `chrome.google.com/webstore` to `chromewebstore.google.com`. This updates the 2 CWS URLs in source files:

- `src/options/modules/ManualAdjustments.js` — Unicodify cross-promotion link
- `src/common/modules/data/Tips.js` — review prompt link

The old URLs currently redirect but may stop resolving as Google phases out the legacy domain.

---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*
---
*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*