### PR TITLE
Make `"<all_urls>"` an optional permission

### DIFF
--- a/scripts/manifests/chrome.json
+++ b/scripts/manifests/chrome.json
@@ -34,14 +34,6 @@
     "type": "module"
   },
 
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "all_frames": true,
-      "match_about_blank": true,
-      "js": ["content_scripts/autocorrect.js"]
-    }
-  ],
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -64,8 +56,11 @@
   "permissions": [
     "storage",
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "scripting"
   ],
+
+  "optional_host_permissions": ["<all_urls>"],
 
   "optional_permissions": [
     "clipboardWrite",

--- a/scripts/manifests/dev.json
+++ b/scripts/manifests/dev.json
@@ -39,14 +39,6 @@
     "type": "module"
   },
 
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "all_frames": true,
-      "match_about_blank": true,
-      "js": ["content_scripts/autocorrect.js"]
-    }
-  ],
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -69,8 +61,11 @@
   "permissions": [
     "storage",
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "scripting"
   ],
+
+  "optional_host_permissions": ["<all_urls>"],
 
   "optional_permissions": [
     "clipboardWrite",

--- a/scripts/manifests/firefox.json
+++ b/scripts/manifests/firefox.json
@@ -39,14 +39,6 @@
     "type": "module"
   },
 
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "all_frames": true,
-      "match_about_blank": true,
-      "js": ["content_scripts/autocorrect.js"]
-    }
-  ],
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -69,8 +61,11 @@
   "permissions": [
     "storage",
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "scripting"
   ],
+
+  "optional_host_permissions": ["<all_urls>"],
 
   "optional_permissions": [
     "clipboardWrite",

--- a/scripts/manifests/thunderbird.json
+++ b/scripts/manifests/thunderbird.json
@@ -46,12 +46,6 @@
     }
   },
 
-  "compose_scripts": [
-    {
-      "js": ["content_scripts/autocorrect.js"]
-    }
-  ],
-
   "content_security_policy": {
     "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
   },
@@ -65,7 +59,8 @@
   "permissions": [
     "storage",
     "compose",
-    "menus"
+    "menus",
+    "scripting"
   ],
 
   "optional_permissions": [

--- a/scripts/manifests/thunderbird.json
+++ b/scripts/manifests/thunderbird.json
@@ -46,6 +46,12 @@
     }
   },
 
+  "compose_scripts": [
+    {
+      "js": ["content_scripts/autocorrect.js"]
+    }
+  ],
+
   "content_security_policy": {
     "extension_pages": "default-src 'self'; style-src 'self' 'unsafe-inline'"
   },
@@ -58,7 +64,6 @@
 
   "permissions": [
     "storage",
-    "tabs",
     "compose",
     "menus"
   ],
@@ -70,7 +75,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "awesome-emoji-picker@rugk.github.io",
-      "strict_min_version": "125.0"
+      "strict_min_version": "151.0"
     }
   }
 }

--- a/scripts/manifests/thunderbird.json
+++ b/scripts/manifests/thunderbird.json
@@ -70,7 +70,7 @@
   "browser_specific_settings": {
     "gecko": {
       "id": "awesome-emoji-picker@rugk.github.io",
-      "strict_min_version": "151.0"
+      "strict_min_version": "128.0"
     }
   }
 }

--- a/src/_locales/de/messages.json
+++ b/src/_locales/de/messages.json
@@ -348,9 +348,9 @@
     "message": "https://github.com/rugk/unicodify/wiki/FAQ#why-is-the-autocorrect-feature-experimental",
     "description": "Link for more information about the experimental autocorrect feature."
   },
-  "permissionRequiredTabsAutocorrect": {
-    "message": "Die Berechtigung zum Zugriff auf die Browser-Tabs ist für diese Funktion erforderlich, damit nicht alle Tabs manuell neugeladen müssen, wenn diese Optionen sich ändern.",
-    "description": "The message shown, when the optionAutocorrectEnable option in the settings needs to request permissions to send updated options to all tabs."
+  "permissionRequiredHostAutocorrect": {
+    "message": "Die Berechtigung zum Zugriff auf alle Webseiten ist erforderlich, um die Autokorrektur-Funktion zu aktivieren.",
+    "description": "The message shown, when the optionAutocorrectEnable option in the settings needs to request host permissions to inject the autocorrect content script."
   },
   "optionAutocorrectEnable": {
     "message": "Autokorrektur aktivieren",

--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -339,9 +339,9 @@
     "message": "https://github.com/rugk/unicodify/wiki/FAQ#why-is-the-autocorrect-feature-experimental",
     "description": "Link for more information about the experimental autocorrect feature."
   },
-  "permissionRequiredTabsAutocorrect": {
-    "message": "The permission to access the browser tabs is required for this feature to prevent you having to reload all of them manually if you change these options.",
-    "description": "The message shown, when the optionAutocorrectEnable option in the settings needs to request permissions to send updated options to all tabs."
+  "permissionRequiredHostAutocorrect": {
+    "message": "The permission to access all websites is required to enable the autocorrect feature.",
+    "description": "The message shown, when the optionAutocorrectEnable option in the settings needs to request host permissions to inject the autocorrect content script."
   },
   "optionAutocorrectEnable": {
     "message": "Enable autocorrection",

--- a/src/_locales/fr/messages.json
+++ b/src/_locales/fr/messages.json
@@ -373,10 +373,9 @@
     "description": "Warning message for experimental autocorrect feature.",
     "hash": "f6b25d9c9a95653e6ca3ebdadd8a9f9e"
   },
-  "permissionRequiredTabsAutocorrect": {
-    "message": "Le droit d'accès aux onglets du navigateur est nécessaire pour cette fonctionnalité, afin d'éviter de devoir les recharger manuellement quand vous changez ces paramètres.",
-    "description": "The message shown, when the optionAutocorrectEnable option in the settings needs to request permissions to send updated options to all tabs.",
-    "hash": "1cd70b15f711c5c70713bab7877b4c9a"
+  "permissionRequiredHostAutocorrect": {
+    "message": "Le droit d'accès à tous les sites web est nécessaire pour activer la fonctionnalité de correction automatique.",
+    "description": "The message shown, when the optionAutocorrectEnable option in the settings needs to request host permissions to inject the autocorrect content script."
   },
   "optionAutocorrectEnable": {
     "message": "Activer la correction automatique",

--- a/src/common/modules/AutocorrectHandler.js
+++ b/src/common/modules/AutocorrectHandler.js
@@ -42,6 +42,9 @@ let antipatterns = null;
 
 const emojiShortcodes = {};
 
+/** This Promise is pending while setSettings() is in progress, and is resolved at all other times. */
+let settingsReady = Promise.resolve();
+
 /**
  * Traverse Trie tree of objects to create RegEx.
  *
@@ -205,6 +208,10 @@ async function applySettings(forceRebuild) {
  * @returns {Promise<void>}
  */
 async function setSettings(autocorrect, modified = true) {
+    /** @type {{promise: Promise<void>, resolve: () => void}} */
+    const { promise, resolve } = Promise.withResolvers();
+    settingsReady = promise;
+
     settings.enabled = autocorrect.enabled;
     settings.autocorrectEmojis = autocorrect.autocorrectEmojis;
     settings.autocorrectEmojiShortcodes = autocorrect.autocorrectEmojiShortcodes;
@@ -214,6 +221,8 @@ async function setSettings(autocorrect, modified = true) {
     if (settings.enabled) {
         await applySettings(/* forceRebuild= */ modified);
     }
+
+    resolve();
 }
 
 /**
@@ -223,39 +232,142 @@ async function setSettings(autocorrect, modified = true) {
  * @returns {Promise<void>}
  */
 async function sendSettings(autocorrect) {
-    await setSettings(autocorrect, /* modified= */ true);
+    const wasEnabled = settings.enabled;
+    settingsReady = setSettings(autocorrect, /* modified= */ true);
+    await settingsReady;
+
     const IS_CHROME = await isChrome();
 
     try {
         const tabs = await browser.tabs.query({});
         await Promise.allSettled(
-            tabs.map(async (tab) => {
-                if (!tab.id) {
-                    return;
-                }
-                try {
-                    await browser.tabs.sendMessage(tab.id, {
-                        type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_CONTENT,
-                        enabled: settings.enabled,
-                        autocomplete: settings.autocomplete,
-                        autocompleteSelect: settings.autocompleteSelect,
-                        autocorrections,
-                        longest,
-                        symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
-                        antipatterns: IS_CHROME ? antipatterns.source : antipatterns,
-                        emojiShortcodes
-                    });
-                } catch (error) {
-                    console.error(
-                        `Error sending autocorrect settings to tab ${tab.id}:`,
-                        error
-                    );
-                }
-            })
+            tabs.map((tab) => sendSettingsToTab(tab, IS_CHROME))
         );
     } catch (error) {
         console.error("Error querying tabs:", error);
     }
+
+    // If transitioning to disabled, stop future injections
+    if (wasEnabled && !settings.enabled) {
+        await unregisterAutocorrectScript();
+    }
+}
+
+/**
+ * Send autocorrect settings to a specific tab.
+ *
+ * @param {browser.tabs.Tab} tab
+ * @param {boolean} isChrome
+ * @returns {Promise<void>}
+ */
+async function sendSettingsToTab(tab, isChrome) {
+    if (!tab.id) {
+        return;
+    }
+    try {
+        await browser.tabs.sendMessage(tab.id, autocorrectContentMessage(isChrome));
+    } catch (error) {
+        console.error(
+            `Error sending autocorrect settings to tab ${tab.id}:`,
+            error,
+        );
+    }
+};
+
+/**
+ * Return the message object containing autocorrect settings and patterns to be sent to content scripts.
+ *
+ * @param {boolean} isChrome
+ * @returns {object}
+ */
+function autocorrectContentMessage(isChrome) {
+    return {
+        type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_CONTENT,
+        enabled: settings.enabled,
+        autocomplete: settings.autocomplete,
+        autocompleteSelect: settings.autocompleteSelect,
+        autocorrections,
+        longest,
+        symbolpatterns: isChrome ? symbolpatterns.source : symbolpatterns,
+        antipatterns: isChrome ? antipatterns.source : antipatterns,
+        emojiShortcodes,
+    }
+}
+
+/**
+ * Register the autocorrect content script dynamically.
+ *
+ * @returns {Promise<void>}
+ */
+async function registerAutocorrectScript() {
+    // Scripting API is not available in Thunderbird.
+    if (!browser.scripting?.registerContentScripts) {
+        return;
+    }
+
+    const existing = await browser.scripting.getRegisteredContentScripts({ ids: ["autocorrect"] });
+    if (existing.length > 0) {
+        return;
+    }
+
+    await browser.scripting.registerContentScripts([{
+        id: "autocorrect",
+        matches: ["<all_urls>"],
+        allFrames: true,
+        js: ["/content_scripts/autocorrect.js"],
+        persistAcrossSessions: true,
+        runAt: "document_idle"
+    }]);
+}
+
+/**
+ * Unregister the autocorrect content script.
+ *
+ * @returns {Promise<void>}
+ */
+async function unregisterAutocorrectScript() {
+    if (!browser.scripting?.unregisterContentScripts) {
+        return;
+    }
+
+    try {
+        await browser.scripting.unregisterContentScripts({ ids: ["autocorrect"] });
+    } catch {
+        // Not registered. Safely ignore.
+    }
+}
+
+/**
+ * Inject the autocorrect script into all currently open tabs.
+ * Used immediately after enabling autocorrect so existing tabs get the script
+ * without requiring a page reload.
+ *
+ * @returns {Promise<void>}
+ */
+async function injectIntoExistingTabs() {
+    if (!browser.scripting?.executeScript) {
+        return;
+    }
+
+    const IS_CHROME = await isChrome();
+
+    const tabs = await browser.tabs.query({}).catch(() => []);
+    await Promise.allSettled(
+        tabs.map(async (tab) => {
+            if (!tab.id) {
+                return;
+            }
+            try {
+                await browser.scripting.executeScript({
+                    target: { tabId: tab.id, allFrames: true },
+                    files: ["/content_scripts/autocorrect.js"]
+                });
+                await sendSettingsToTab(tab, IS_CHROME);
+            } catch {
+                // Tabs such as about:, moz-extension:, and internal pages will throw. Safely ignore.
+            }
+        })
+    );
 }
 
 /**
@@ -301,25 +413,28 @@ BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROU
     return sendSettings(request.optionValue);
 });
 
+BrowserCommunication.addListener(COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_REGISTER_SCRIPT, async () => {
+    // Wait for any in-flight setSettings() from AUTOCORRECT_BACKGROUND to finish
+    // before injecting, so content scripts get the latest patterns on initial load.
+    await settingsReady;
+    await registerAutocorrectScript();
+    await injectIntoExistingTabs();
+});
+
+// Handle host permission being externally revoked (e.g., via browser settings UI)
+browser.permissions.onRemoved?.addListener(async (permissions) => {
+    if (permissions.origins?.includes("<all_urls>")) {
+        await unregisterAutocorrectScript();
+    }
+});
+
 browser.runtime.onMessage.addListener(async (message, _sender) => {
     const IS_CHROME = await isChrome();
 
     if (message.type === COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_CONTENT) {
         // Ensure autocorrect data is initialized before responding to content script requests.
         await isInitialized;
-
-        const response = {
-            type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_CONTENT,
-            enabled: settings.enabled,
-            autocomplete: settings.autocomplete,
-            autocompleteSelect: settings.autocompleteSelect,
-            autocorrections,
-            longest,
-            symbolpatterns: IS_CHROME ? symbolpatterns.source : symbolpatterns,
-            antipatterns: IS_CHROME ? antipatterns.source : antipatterns,
-            emojiShortcodes
-        };
-        return response;
+        return autocorrectContentMessage(IS_CHROME);
     }
 });
 

--- a/src/common/modules/AutocorrectHandler.js
+++ b/src/common/modules/AutocorrectHandler.js
@@ -300,11 +300,6 @@ function autocorrectContentMessage(isChrome) {
  * @returns {Promise<void>}
  */
 async function registerAutocorrectScript() {
-    // Scripting API is not available in Thunderbird.
-    if (!browser.scripting?.registerContentScripts) {
-        return;
-    }
-
     const existing = await browser.scripting.getRegisteredContentScripts({ ids: ["autocorrect"] });
     if (existing.length > 0) {
         return;
@@ -326,10 +321,6 @@ async function registerAutocorrectScript() {
  * @returns {Promise<void>}
  */
 async function unregisterAutocorrectScript() {
-    if (!browser.scripting?.unregisterContentScripts) {
-        return;
-    }
-
     try {
         await browser.scripting.unregisterContentScripts({ ids: ["autocorrect"] });
     } catch {
@@ -345,10 +336,6 @@ async function unregisterAutocorrectScript() {
  * @returns {Promise<void>}
  */
 async function injectIntoExistingTabs() {
-    if (!browser.scripting?.executeScript) {
-        return;
-    }
-
     const IS_CHROME = await isChrome();
 
     const tabs = await browser.tabs.query({}).catch(() => []);
@@ -392,17 +379,6 @@ export async function init() {
     console.debug("Emoji shortcodes:", emojiShortcodes);
 
     await setSettings(autocorrect, /* modified= */ false);
-
-    // Thunderbird
-    // Cannot register scripts in manifest.json file: https://bugzilla.mozilla.org/show_bug.cgi?id=1902843
-    if (browser.composeScripts) {
-        browser.composeScripts.register({
-            js: [
-                { file: "/content_scripts/autocorrect.js" }
-            ]
-        });
-    }
-
     initializedResolver();
 }
 

--- a/src/common/modules/AutocorrectHandler.js
+++ b/src/common/modules/AutocorrectHandler.js
@@ -378,6 +378,16 @@ export async function init() {
     Object.freeze(emojiShortcodes);
     console.debug("Emoji shortcodes:", emojiShortcodes);
 
+    // Thunderbird
+    // Replace this with manifest.json registration when the fix for this bug is deployed to Thunderbird ESR:
+    // https://bugzilla.mozilla.org/show_bug.cgi?id=1902843
+    browser.scripting?.compose?.registerScripts?.([
+        {
+            id: "autocorrect-compose",
+            js: ["/content_scripts/autocorrect.js"],
+        }
+    ]);
+
     await setSettings(autocorrect, /* modified= */ false);
     initializedResolver();
 }

--- a/src/common/modules/data/BrowserCommunicationTypes.js
+++ b/src/common/modules/data/BrowserCommunicationTypes.js
@@ -15,6 +15,7 @@ export const COMMUNICATION_MESSAGE_TYPE = Object.freeze({
     OMNIBAR_TOGGLE: "omnibarToggle",
     AUTOCORRECT_BACKGROUND: "autocorrectBackground",
     AUTOCORRECT_CONTENT: "autocorrectContent",
+    AUTOCORRECT_REGISTER_SCRIPT: "autocorrectRegisterScript",
     CONTEXT_MENU: "contextMenu",
     INSERT: "insert"
 });

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -1,349 +1,356 @@
 
 
-// communication type
-// directly include magic constant as a workaround as we cannot import modules in content scripts due to https://bugzilla.mozilla.org/show_bug.cgi?id=1451545
-const AUTOCORRECT_CONTENT = "autocorrectContent";
-const INSERT = "insert";
+// Guard against double-initialization when injected via both registerContentScripts
+// (persistent, fires on page load) and executeScript (immediate injection into open tabs).
+if (!window.__awesomeEmojiPickerAutocorrectLoaded) {
+    window.__awesomeEmojiPickerAutocorrectLoaded = true;
+    console.debug("Awesome Emoji Picker autocorrect loaded.");
 
-const segmenter = new Intl.Segmenter();
+    // communication type
+    // directly include magic constant as a workaround as we cannot import modules in content scripts due to https://bugzilla.mozilla.org/show_bug.cgi?id=1451545
+    const AUTOCORRECT_CONTENT = "autocorrectContent";
+    const INSERT = "insert";
 
-let insertedText; // Last insert text
-let deletedText; // Last deleted text
-let lastTarget; // Last target
-let lastCaretPosition; // Last caret position
+    const segmenter = new Intl.Segmenter();
 
-let enabled = false;
-let autocomplete = true;
-let autocompleteSelect = false;
+    let insertedText; // Last insert text
+    let deletedText; // Last deleted text
+    let lastTarget; // Last target
+    let lastCaretPosition; // Last caret position
 
-let autocorrections = {};
+    let enabled = false;
+    let autocomplete = true;
+    let autocompleteSelect = false;
 
-let longest = 0;
+    let autocorrections = {};
 
-// Regular expressions
-let symbolpatterns = null;
-// Exceptions, do not autocorrect for these patterns
-let antipatterns = null;
+    let longest = 0;
 
-let emojiShortcodes = {};
+    // Regular expressions
+    let symbolpatterns = null;
+    // Exceptions, do not autocorrect for these patterns
+    let antipatterns = null;
 
-let running = false;
+    let emojiShortcodes = {};
 
-/**
- * Get caret position.
- *
- * @param {HTMLElement} target
- * @returns {number|null}
- */
-function getCaretPosition(target) {
-    // ContentEditable elements
-    if (target.isContentEditable || document.designMode === "on") {
-        target.focus();
-        const selection = document.getSelection();
-        if (selection.rangeCount !== 1) {
+    let running = false;
+
+    /**
+     * Get caret position.
+     *
+     * @param {HTMLElement} target
+     * @returns {number|null}
+     */
+    function getCaretPosition(target) {
+        // ContentEditable elements
+        if (target.isContentEditable || document.designMode === "on") {
+            target.focus();
+            const selection = document.getSelection();
+            if (selection.rangeCount !== 1) {
+                return null;
+            }
+            const arange = selection.getRangeAt(0);
+            if (!arange.collapsed) {
+                return null;
+            }
+            const range = arange.cloneRange();
+            const temp = document.createTextNode("\0");
+            range.insertNode(temp);
+            const caretposition = target.innerText.indexOf("\0");
+            temp.remove();
+            return caretposition;
+        }
+        // input and textarea fields
+        if (target.selectionStart !== target.selectionEnd) {
             return null;
         }
-        const arange = selection.getRangeAt(0);
-        if (!arange.collapsed) {
-            return null;
-        }
-        const range = arange.cloneRange();
-        const temp = document.createTextNode("\0");
-        range.insertNode(temp);
-        const caretposition = target.innerText.indexOf("\0");
-        temp.remove();
-        return caretposition;
-    }
-    // input and textarea fields
-    if (target.selectionStart !== target.selectionEnd) {
-        return null;
-    }
-    return target.selectionStart;
-}
-
-/**
- * Insert at caret in the given element.
- * Adapted from: https://www.everythingfrontend.com/posts/insert-text-into-textarea-at-cursor-position.html
- *
- * @param {HTMLElement} target
- * @param {string} atext
- * @throws {Error} if nothing is selected
- * @returns {void}
- */
-function insertAtCaret(target, atext) {
-    // document.execCommand is deprecated, although there is not yet an alternative: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
-    // insertReplacementText
-    if (document.execCommand("insertText", false, atext)) {
-        return;
+        return target.selectionStart;
     }
 
-    // Firefox input and textarea fields: https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
-    if (target.setRangeText) {
-        const start = target.selectionStart;
-        const end = target.selectionEnd;
-
-        if (start != null && end != null) {
-            target.setRangeText(atext);
-
-            target.selectionStart = target.selectionEnd = start + atext.length;
-
-            // Notify any possible listeners of the change
-            const event = document.createEvent("UIEvent");
-            event.initEvent("input", true, false);
-            target.dispatchEvent(event);
-
+    /**
+     * Insert at caret in the given element.
+     * Adapted from: https://www.everythingfrontend.com/posts/insert-text-into-textarea-at-cursor-position.html
+     *
+     * @param {HTMLElement} target
+     * @param {string} atext
+     * @throws {Error} if nothing is selected
+     * @returns {void}
+     */
+    function insertAtCaret(target, atext) {
+        // document.execCommand is deprecated, although there is not yet an alternative: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+        // insertReplacementText
+        if (document.execCommand("insertText", false, atext)) {
             return;
         }
-    }
 
-    throw new Error("nothing selected");
-}
-
-/**
- * Insert at caret in the given element and select.
- *
- * @param {HTMLElement} target
- * @param {string} atext
- * @returns {void}
- */
-function insertAndSelect(target, atext) {
-    insertAtCaret(target, atext);
-    // ContentEditable elements
-    if (target.isContentEditable || document.designMode === "on") {
-        const range = document.getSelection().getRangeAt(0);
-        range.setStart(range.startContainer, range.startOffset - atext.length);
-    }
-    // input and textarea fields
-    else {
-        target.selectionStart -= atext.length;
-    }
-}
-
-/**
- * Insert into page.
- *
- * @param {string} atext
- * @returns {void}
- */
-function insertIntoPage(atext) {
-    return insertAtCaret(document.activeElement, atext);
-}
-
-/**
- * Count Unicode characters.
- * Adapted from: https://blog.jonnew.com/posts/poo-dot-length-equals-two
- *
- * @param {string} str
- * @returns {number}
- */
-function countChars(str) {
-    // removing the Unicode joiner chars \u200D
-    return Array.from(segmenter.segment(str.replaceAll("\u200D", ""))).length;
-}
-
-/**
- * Delete at caret.
- *
- * @param {HTMLElement} target
- * @param {string} atext
- * @returns {void}
- */
-function deleteCaret(target, atext) {
-    const count = countChars(atext);
-    if (count > 0) {
-        // document.execCommand is deprecated, although there is not yet an alternative: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
-        if (document.execCommand("delete", false)) {
-            for (let i = 0; i < count - 1; ++i) {
-                document.execCommand("delete", false);
-            }
-        }
         // Firefox input and textarea fields: https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
-        else if (target.setRangeText) {
+        if (target.setRangeText) {
             const start = target.selectionStart;
+            const end = target.selectionEnd;
 
-            target.selectionStart = start - atext.length;
-            target.selectionEnd = start;
-            target.setRangeText("");
+            if (start != null && end != null) {
+                target.setRangeText(atext);
 
-            // Notify any possible listeners of the change
-            const e = document.createEvent("UIEvent");
-            e.initEvent("input", true, false);
-            target.dispatchEvent(e);
+                target.selectionStart = target.selectionEnd = start + atext.length;
+
+                // Notify any possible listeners of the change
+                const event = document.createEvent("UIEvent");
+                event.initEvent("input", true, false);
+                target.dispatchEvent(event);
+
+                return;
+            }
+        }
+
+        throw new Error("nothing selected");
+    }
+
+    /**
+     * Insert at caret in the given element and select.
+     *
+     * @param {HTMLElement} target
+     * @param {string} atext
+     * @returns {void}
+     */
+    function insertAndSelect(target, atext) {
+        insertAtCaret(target, atext);
+        // ContentEditable elements
+        if (target.isContentEditable || document.designMode === "on") {
+            const range = document.getSelection().getRangeAt(0);
+            range.setStart(range.startContainer, range.startOffset - atext.length);
+        }
+        // input and textarea fields
+        else {
+            target.selectionStart -= atext.length;
         }
     }
-}
 
-/**
- * Autocorrect on text input even by evaluating the keys and replacing the characters/string.
- *
- * @param {InputEvent} event
- * @returns {void}
- */
-function autocorrect(event) {
-    // console.log('beforeinput', event.inputType, event.data);
-    if (!["insertText", "insertCompositionText", "insertParagraph", "insertLineBreak"].includes(event.inputType)) {
-        return;
+    /**
+     * Insert into page.
+     *
+     * @param {string} atext
+     * @returns {void}
+     */
+    function insertIntoPage(atext) {
+        return insertAtCaret(document.activeElement, atext);
     }
-    if (!symbolpatterns) {
-        throw new Error("Emoji autocorrect settings have not been received. Do not autocorrect.");
+
+    /**
+     * Count Unicode characters.
+     * Adapted from: https://blog.jonnew.com/posts/poo-dot-length-equals-two
+     *
+     * @param {string} str
+     * @returns {number}
+     */
+    function countChars(str) {
+        // removing the Unicode joiner chars \u200D
+        return Array.from(segmenter.segment(str.replaceAll("\u200D", ""))).length;
     }
-    if (running) {
-        return;
-    }
-    running = true;
-    const { target } = event;
-    const caretposition = getCaretPosition(target);
-    if (caretposition != null) {
-        const value = target.value || target.innerText;
-        let deletecount = 0;
-        let insert = ["insertLineBreak", "insertParagraph"].includes(event.inputType) ? "\n" : event.data;
-        const inserted = insert;
-        let output = false;
-        const previousText = value.slice(caretposition < longest ? 0 : caretposition - longest, caretposition);
-        const regexResult = symbolpatterns.exec(previousText);
-        // Autocorrect :colon: Emoji Shortcodes and/or Emoticon Emojis and/or Unicode Symbols
-        if (regexResult) {
-            const length = longest - 1;
-            const text = value.slice(caretposition < length ? 0 : caretposition - length, caretposition) + inserted;
-            const aregexResult = symbolpatterns.exec(text);
-            if (!antipatterns.test(text) && (!aregexResult || (caretposition <= longest ? regexResult.index < aregexResult.index : regexResult.index <= aregexResult.index))) {
-                const [autocorrection] = regexResult;
-                insert = autocorrections[autocorrection] + inserted;
-                deletecount = autocorrection.length;
-                output = true;
+
+    /**
+     * Delete at caret.
+     *
+     * @param {HTMLElement} target
+     * @param {string} atext
+     * @returns {void}
+     */
+    function deleteCaret(target, atext) {
+        const count = countChars(atext);
+        if (count > 0) {
+            // document.execCommand is deprecated, although there is not yet an alternative: https://developer.mozilla.org/en-US/docs/Web/API/Document/execCommand
+            if (document.execCommand("delete", false)) {
+                for (let i = 0; i < count - 1; ++i) {
+                    document.execCommand("delete", false);
+                }
             }
-        } else {
-            // Autocomplete :colon: Emoji Shortcodes
-            if (autocomplete) {
-                // Emoji Shortcode
-                const re = /:[a-z0-9-+_]+$/u;
-                const length = longest - 2;
-                const text = value.slice(caretposition < length ? 0 : caretposition - length, caretposition) + inserted;
-                const regexResult = re.exec(text);
-                if (regexResult) {
-                    const [shortcode] = regexResult;
-                    const aregexResult = Object.keys(emojiShortcodes).filter((item) => item.indexOf(shortcode) === 0);
-                    if (aregexResult.length >= 1 && (shortcode.length > 2 || aregexResult[0].length === 3)) {
-                        const ainsert = aregexResult[0].slice(shortcode.length);
-                        if (autocompleteSelect || aregexResult.length > 1) {
-                            event.preventDefault();
+            // Firefox input and textarea fields: https://bugzilla.mozilla.org/show_bug.cgi?id=1220696
+            else if (target.setRangeText) {
+                const start = target.selectionStart;
 
-                            insertAtCaret(target, inserted);
-                            insertAndSelect(target, ainsert);
-                        } else {
-                            insert = inserted + ainsert;
-                            output = true;
+                target.selectionStart = start - atext.length;
+                target.selectionEnd = start;
+                target.setRangeText("");
+
+                // Notify any possible listeners of the change
+                const e = document.createEvent("UIEvent");
+                e.initEvent("input", true, false);
+                target.dispatchEvent(e);
+            }
+        }
+    }
+
+    /**
+     * Autocorrect on text input even by evaluating the keys and replacing the characters/string.
+     *
+     * @param {InputEvent} event
+     * @returns {void}
+     */
+    function autocorrect(event) {
+        // console.log('beforeinput', event.inputType, event.data);
+        if (!["insertText", "insertCompositionText", "insertParagraph", "insertLineBreak"].includes(event.inputType)) {
+            return;
+        }
+        if (!symbolpatterns) {
+            throw new Error("Emoji autocorrect settings have not been received. Do not autocorrect.");
+        }
+        if (running) {
+            return;
+        }
+        running = true;
+        const { target } = event;
+        const caretposition = getCaretPosition(target);
+        if (caretposition != null) {
+            const value = target.value || target.innerText;
+            let deletecount = 0;
+            let insert = ["insertLineBreak", "insertParagraph"].includes(event.inputType) ? "\n" : event.data;
+            const inserted = insert;
+            let output = false;
+            const previousText = value.slice(caretposition < longest ? 0 : caretposition - longest, caretposition);
+            const regexResult = symbolpatterns.exec(previousText);
+            // Autocorrect :colon: Emoji Shortcodes and/or Emoticon Emojis and/or Unicode Symbols
+            if (regexResult) {
+                const length = longest - 1;
+                const text = value.slice(caretposition < length ? 0 : caretposition - length, caretposition) + inserted;
+                const aregexResult = symbolpatterns.exec(text);
+                if (!antipatterns.test(text) && (!aregexResult || (caretposition <= longest ? regexResult.index < aregexResult.index : regexResult.index <= aregexResult.index))) {
+                    const [autocorrection] = regexResult;
+                    insert = autocorrections[autocorrection] + inserted;
+                    deletecount = autocorrection.length;
+                    output = true;
+                }
+            } else {
+                // Autocomplete :colon: Emoji Shortcodes
+                if (autocomplete) {
+                    // Emoji Shortcode
+                    const re = /:[a-z0-9-+_]+$/u;
+                    const length = longest - 2;
+                    const text = value.slice(caretposition < length ? 0 : caretposition - length, caretposition) + inserted;
+                    const regexResult = re.exec(text);
+                    if (regexResult) {
+                        const [shortcode] = regexResult;
+                        const aregexResult = Object.keys(emojiShortcodes).filter((item) => item.indexOf(shortcode) === 0);
+                        if (aregexResult.length >= 1 && (shortcode.length > 2 || aregexResult[0].length === 3)) {
+                            const ainsert = aregexResult[0].slice(shortcode.length);
+                            if (autocompleteSelect || aregexResult.length > 1) {
+                                event.preventDefault();
+
+                                insertAtCaret(target, inserted);
+                                insertAndSelect(target, ainsert);
+                            } else {
+                                insert = inserted + ainsert;
+                                output = true;
+                            }
                         }
                     }
                 }
             }
-        }
-        if (output) {
-            event.preventDefault();
+            if (output) {
+                event.preventDefault();
 
-            const text = deletecount ? value.slice(caretposition - deletecount, caretposition) : "";
-            if (text) {
-                lastTarget = null;
-                deleteCaret(target, text);
+                const text = deletecount ? value.slice(caretposition - deletecount, caretposition) : "";
+                if (text) {
+                    lastTarget = null;
+                    deleteCaret(target, text);
+                }
+                insertAtCaret(target, insert);
+
+                insertedText = insert;
+                deletedText = text + inserted;
+                console.debug("Autocorrect: “%s” was replaced with “%s”.", deletedText, insertedText);
+
+                lastTarget = target;
+                lastCaretPosition = caretposition - deletecount + insert.length;
+
+                if (deletedText && insertedText.startsWith(deletedText)) {
+                    insertedText = insertedText.slice(deletedText.length);
+                    deletedText = "";
+                }
             }
-            insertAtCaret(target, insert);
+        }
+        running = false;
+    }
 
-            insertedText = insert;
-            deletedText = text + inserted;
-            console.debug("Autocorrect: “%s” was replaced with “%s”.", deletedText, insertedText);
+    /**
+     * Undo autocorrect in case the backspace has been pressed.
+     *
+     * @param {InputEvent} event
+     * @returns {void}
+     */
+    function undoAutocorrect(event) {
+        // console.log('beforeinput', event.inputType, event.data);
+        // Backspace
+        if (event.inputType !== "deleteContentBackward") {
+            return;
+        }
+        if (running) {
+            return;
+        }
+        running = true;
+        const { target } = event;
+        const caretposition = getCaretPosition(target);
+        if (caretposition != null) {
+            if (target === lastTarget && caretposition === lastCaretPosition) {
+                event.preventDefault();
 
-            lastTarget = target;
-            lastCaretPosition = caretposition - deletecount + insert.length;
-
-            if (deletedText && insertedText.startsWith(deletedText)) {
-                insertedText = insertedText.slice(deletedText.length);
-                deletedText = "";
+                if (insertedText) {
+                    lastTarget = null;
+                    deleteCaret(target, insertedText);
+                }
+                if (deletedText) {
+                    insertAtCaret(target, deletedText);
+                }
+                console.debug("Undo autocorrect: “%s” was replaced with “%s”.", insertedText, deletedText);
             }
+
+            lastTarget = null;
+        }
+        running = false;
+    }
+
+    /**
+     * Handle response from the autocorrect module.
+     *
+     * @param {object} message
+     * @param {object} sender
+     * @returns {void}
+     */
+    function handleResponse(message, _sender) {
+        if (message.type === AUTOCORRECT_CONTENT) {
+            ({
+                enabled,
+                autocomplete,
+                autocompleteSelect,
+                autocorrections,
+                longest,
+                symbolpatterns,
+                antipatterns,
+                emojiShortcodes
+            } = message);
+            symbolpatterns = typeof symbolpatterns === "string" ? new RegExp(symbolpatterns, "u") : symbolpatterns;
+            antipatterns = typeof antipatterns === "string" ? new RegExp(antipatterns, "u") : antipatterns;
+
+            if (enabled) {
+                addEventListener("beforeinput", undoAutocorrect, true);
+                addEventListener("beforeinput", autocorrect, true);
+            } else {
+                removeEventListener("beforeinput", undoAutocorrect, true);
+                removeEventListener("beforeinput", autocorrect, true);
+            }
+        } else if (message.type === INSERT) {
+            insertIntoPage(message.text);
         }
     }
-    running = false;
-}
 
-/**
- * Undo autocorrect in case the backspace has been pressed.
- *
- * @param {InputEvent} event
- * @returns {void}
- */
-function undoAutocorrect(event) {
-    // console.log('beforeinput', event.inputType, event.data);
-    // Backspace
-    if (event.inputType !== "deleteContentBackward") {
-        return;
+    /**
+     * Handle errors from messages and responses.
+     *
+     * @param {string} error
+     * @returns {void}
+     */
+    function handleError(error) {
+        console.error(`Error: ${error}`);
     }
-    if (running) {
-        return;
-    }
-    running = true;
-    const { target } = event;
-    const caretposition = getCaretPosition(target);
-    if (caretposition != null) {
-        if (target === lastTarget && caretposition === lastCaretPosition) {
-            event.preventDefault();
 
-            if (insertedText) {
-                lastTarget = null;
-                deleteCaret(target, insertedText);
-            }
-            if (deletedText) {
-                insertAtCaret(target, deletedText);
-            }
-            console.debug("Undo autocorrect: “%s” was replaced with “%s”.", insertedText, deletedText);
-        }
-
-        lastTarget = null;
-    }
-    running = false;
+    browser.runtime.sendMessage({ type: AUTOCORRECT_CONTENT }).then(handleResponse, handleError);
+    browser.runtime.onMessage.addListener(handleResponse);
 }
-
-/**
- * Handle response from the autocorrect module.
- *
- * @param {object} message
- * @param {object} sender
- * @returns {void}
- */
-function handleResponse(message, _sender) {
-    if (message.type === AUTOCORRECT_CONTENT) {
-        ({
-            enabled,
-            autocomplete,
-            autocompleteSelect,
-            autocorrections,
-            longest,
-            symbolpatterns,
-            antipatterns,
-            emojiShortcodes
-        } = message);
-        symbolpatterns = typeof symbolpatterns === "string" ? new RegExp(symbolpatterns, "u") : symbolpatterns;
-        antipatterns = typeof antipatterns === "string" ? new RegExp(antipatterns, "u") : antipatterns;
-
-        if (enabled) {
-            addEventListener("beforeinput", undoAutocorrect, true);
-            addEventListener("beforeinput", autocorrect, true);
-        } else {
-            removeEventListener("beforeinput", undoAutocorrect, true);
-            removeEventListener("beforeinput", autocorrect, true);
-        }
-    } else if (message.type === INSERT) {
-        insertIntoPage(message.text);
-    }
-}
-
-/**
- * Handle errors from messages and responses.
- *
- * @param {string} error
- * @returns {void}
- */
-function handleError(error) {
-    console.error(`Error: ${error}`);
-}
-
-browser.runtime.sendMessage({ type: AUTOCORRECT_CONTENT }).then(handleResponse, handleError);
-browser.runtime.onMessage.addListener(handleResponse);

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -2,8 +2,8 @@
 
 // Guard against double-initialization when injected via both registerContentScripts
 // (persistent, fires on page load) and executeScript (immediate injection into open tabs).
-if (!window.__awesomeEmojiPickerAutocorrectLoaded) {
-    window.__awesomeEmojiPickerAutocorrectLoaded = true;
+if (!globalThis.__awesomeEmojiPickerAutocorrectLoaded) {
+    globalThis.__awesomeEmojiPickerAutocorrectLoaded = true;
     console.debug("Awesome Emoji Picker autocorrect loaded.");
 
     // communication type

--- a/src/content_scripts/autocorrect.js
+++ b/src/content_scripts/autocorrect.js
@@ -4,7 +4,6 @@
 // (persistent, fires on page load) and executeScript (immediate injection into open tabs).
 if (!globalThis.__awesomeEmojiPickerAutocorrectLoaded) {
     globalThis.__awesomeEmojiPickerAutocorrectLoaded = true;
-    console.debug("Awesome Emoji Picker autocorrect loaded.");
 
     // communication type
     // directly include magic constant as a workaround as we cannot import modules in content scripts due to https://bugzilla.mozilla.org/show_bug.cgi?id=1451545

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -39,14 +39,6 @@
     "type": "module"
   },
 
-  "content_scripts": [
-    {
-      "matches": ["<all_urls>"],
-      "all_frames": true,
-      "match_about_blank": true,
-      "js": ["content_scripts/autocorrect.js"]
-    }
-  ],
   "commands": {
     "_execute_action": {
       "suggested_key": {
@@ -69,8 +61,11 @@
   "permissions": [
     "storage",
     "activeTab",
-    "contextMenus"
+    "contextMenus",
+    "scripting"
   ],
+
+  "optional_host_permissions": ["<all_urls>"],
 
   "optional_permissions": [
     "clipboardWrite",

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -77,16 +77,16 @@ function applyAutocorrectPermissions(optionValue, option, event) {
         /** @type {HTMLInputElement} */(document.getElementById("autocompleteSelect")).disabled = true;
     }
 
-    if (IS_THUNDERBIRD) {
-        // Thunderbird does not require the <all_urls> to enable this feature.
-        return Promise.resolve();
-    }
-
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND,
         optionValue
     });
+
+    if (IS_THUNDERBIRD) {
+        // Thunderbird does not require the <all_urls> to enable this feature.
+        return Promise.resolve();
+    }
 
     if (!optionValue.enabled) {
         PermissionRequest.cancelPermissionPrompt(AUTOCORRECT_HOST_PERMISSION, MESSAGE_HOST_PERMISSION);

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -108,7 +108,7 @@ function applyAutocorrectPermissions(optionValue, _option, event) {
     }).catch(() => {
         // if the user denies the permission, we disable the setting again and show an error message
         /** @type {HTMLInputElement} */(document.getElementById("autocorrect")).checked = false;
-        applyAutocorrectPermissions({enabled: false}, _option, event);
+        applyAutocorrectPermissions({enabled: false}, option, event);
     });
 }
 

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -60,11 +60,11 @@ function applyPickerResultPermissions(optionValue) {
  *
  * @private
  * @param  {object} optionValue
- * @param  {string} [_option]
+ * @param  {string} [option]
  * @param  {object} [event]
  * @returns {Promise<any>}
  */
-function applyAutocorrectPermissions(optionValue, _option, event) {
+function applyAutocorrectPermissions(optionValue, option, event) {
     if (optionValue.enabled) {
         /** @type {HTMLInputElement} */(document.getElementById("autocorrectEmojiShortcodes")).disabled = false;
         /** @type {HTMLInputElement} */(document.getElementById("autocorrectEmojis")).disabled = false;

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -77,6 +77,11 @@ function applyAutocorrectPermissions(optionValue, option, event) {
         /** @type {HTMLInputElement} */(document.getElementById("autocompleteSelect")).disabled = true;
     }
 
+    if (IS_THUNDERBIRD) {
+        // Thunderbird does not require the <all_urls> to enable this feature.
+        return Promise.resolve();
+    }
+
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND,
@@ -494,10 +499,15 @@ export async function registerTrigger() {
         /** @type {HTMLElement} */document.getElementById("searchActionCopyPermissionInfo"),
         "permissionRequiredClipboardWrite"
     );
-    await PermissionRequest.registerPermissionMessageBox(
-        AUTOCORRECT_HOST_PERMISSION,
-        MESSAGE_HOST_PERMISSION,
-        /** @type {HTMLElement} */(document.getElementById("hostPermissionInfo")),
-        "permissionRequiredHostAutocorrect"
-    );
+
+    if (!IS_THUNDERBIRD) {
+        await PermissionRequest.registerPermissionMessageBox(
+            AUTOCORRECT_HOST_PERMISSION,
+            MESSAGE_HOST_PERMISSION,
+            /** @type {HTMLElement} */(document.getElementById("hostPermissionInfo")),
+            "permissionRequiredHostAutocorrect"
+        );
+    } else {
+        /** @type {HTMLElement} */(document.getElementById("hostPermissionInfo")).parentElement?.remove();
+    }
 }

--- a/src/options/modules/CustomOptionTriggers.js
+++ b/src/options/modules/CustomOptionTriggers.js
@@ -14,11 +14,11 @@ import * as IconHandler from "/common/modules/IconHandler.js";
 const CLIPBOARD_WRITE_PERMISSION = {
     permissions: [/** @type {browser._manifest.OptionalPermission} */ "clipboardWrite"]
 };
-const TABS_PERMISSION = {
-    permissions: [/** @type {browser._manifest.OptionalPermission} */ "tabs"]
+const AUTOCORRECT_HOST_PERMISSION = {
+    origins: [/** @type {string} */ ("<all_urls>")]
 };
 const MESSAGE_EMOJI_COPY_PERMISSION_SEARCH = "searchActionCopyPermissionInfo";
-const MESSAGE_TABS_PERMISSION = "tabsPermissionInfo";
+const MESSAGE_HOST_PERMISSION = "hostPermissionInfo";
 
 const MAXIMUM_SEARCH_RESULTS = 21;
 
@@ -77,26 +77,39 @@ function applyAutocorrectPermissions(optionValue, _option, event) {
         /** @type {HTMLInputElement} */(document.getElementById("autocompleteSelect")).disabled = true;
     }
 
-    let retPromise = Promise.resolve();
-
-    if (PermissionRequest.isPermissionGranted(TABS_PERMISSION) // and not already granted
-    ) {
-        PermissionRequest.cancelPermissionPrompt(TABS_PERMISSION, MESSAGE_TABS_PERMISSION);
-    } else {
-        retPromise = PermissionRequest.requestPermission(
-            TABS_PERMISSION,
-            MESSAGE_TABS_PERMISSION,
-            event
-        );
-    }
-
     // trigger update for current session
     browser.runtime.sendMessage({
         type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_BACKGROUND,
         optionValue
     });
 
-    return retPromise;
+    if (!optionValue.enabled) {
+        PermissionRequest.cancelPermissionPrompt(AUTOCORRECT_HOST_PERMISSION, MESSAGE_HOST_PERMISSION);
+        browser.permissions.remove(AUTOCORRECT_HOST_PERMISSION);
+        return Promise.resolve();
+    }
+
+    if (PermissionRequest.isPermissionGranted(AUTOCORRECT_HOST_PERMISSION)) {
+        PermissionRequest.cancelPermissionPrompt(AUTOCORRECT_HOST_PERMISSION, MESSAGE_HOST_PERMISSION);
+        browser.runtime.sendMessage({
+            type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_REGISTER_SCRIPT
+        });
+        return Promise.resolve();
+    }
+
+    return PermissionRequest.requestPermission(
+        AUTOCORRECT_HOST_PERMISSION,
+        MESSAGE_HOST_PERMISSION,
+        event
+    ).then(() => {
+        browser.runtime.sendMessage({
+            type: COMMUNICATION_MESSAGE_TYPE.AUTOCORRECT_REGISTER_SCRIPT
+        });
+    }).catch(() => {
+        // if the user denies the permission, we disable the setting again and show an error message
+        /** @type {HTMLInputElement} */(document.getElementById("autocorrect")).checked = false;
+        applyAutocorrectPermissions({enabled: false}, _option, event);
+    });
 }
 
 /**
@@ -482,9 +495,9 @@ export async function registerTrigger() {
         "permissionRequiredClipboardWrite"
     );
     await PermissionRequest.registerPermissionMessageBox(
-        TABS_PERMISSION,
-        MESSAGE_TABS_PERMISSION,
-        /** @type {HTMLElement} */document.getElementById("tabsPermissionInfo"),
-        "permissionRequiredTabsAutocorrect"
+        AUTOCORRECT_HOST_PERMISSION,
+        MESSAGE_HOST_PERMISSION,
+        /** @type {HTMLElement} */(document.getElementById("hostPermissionInfo")),
+        "permissionRequiredHostAutocorrect"
     );
 }

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -171,7 +171,7 @@
 
 				<ul>
 					<div class="line">
-						<div id="tabsPermissionInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
+						<div id="hostPermissionInfo" aria-label="info message" data-i18n data-i18n-aria-label="__MSG_ariaMessageInfo__" class="message-box info invisible fade-hide">
 							<span class="message-text">Permission requested.</span>
 							<a href="#">
 								<button type="button" class="message-action-button micro-button info invisible"></button>


### PR DESCRIPTION
Fix #171 

Took me a while to get to this because my day job got busy again

Details:
* Injects the content script using `browser.scripting` instead of hard coding it into the manifest file
* Only requests the optional permission when the user enables autocorrect in the extension's settings
* Automatically revokes this permission when the user disabled the autocorrect feature
* Removes `tabs` permission: `tabs` is only required to get the title and URL of the tabs. Without it the browser returns a barebones tab object but it includes `tab.id` which is all we need
* I used Google Translate for the `de` and `fr` locales, so please double-check my work on those :)